### PR TITLE
Added cli option to allow no prefix for tag attribute

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -27,9 +27,11 @@ if(process.argv[2] === "--help" || process.argv[2] === "-h"){
             options.ignoreTextNodeAttr = true;
         }else if(process.argv[i] === "-o"){
             outputFileName = process.argv[++i];
+        }else if(process.argv[i] === "-np"){ // no prefix for attribute
+            options.attrPrefix = "";
         }else{//filename
             fileName = process.argv[i];
-        }
+        }		
     }
     try{
         var xmlData = fs.readFileSync(fileName).toString();


### PR DESCRIPTION
For my project i needed tag attribute without any default prefix like "@_" so i have forked this project and modified cli.js to allow no prefix for tag attribute through  cli option as "-np" (no prefix) .  

Usage before :
$xml2js [-ns|-a|] <filename> [-o outputfile.json]

Usage After :
$xml2js [-ns|-a|-np] <filename> [-o outputfile.json]

