### PR TITLE
Add arrayMode option to parse any nodes as arrays

### DIFF
--- a/bin/parser.js
+++ b/bin/parser.js
@@ -23,12 +23,13 @@ var defaultOptions = {
     ignoreNameSpace : false,
     ignoreRootElement : false,
     textNodeConversion : true,
-    textAttrConversion : false
+    textAttrConversion : false,
+    arrayMode : false
 };
 
 var buildOptions = function (options){
     if(!options) options = {};
-    var props = ["attrPrefix","ignoreNonTextNodeAttr","ignoreTextNodeAttr","ignoreNameSpace","ignoreRootElement","textNodeName","textNodeConversion","textAttrConversion"];
+    var props = ["attrPrefix","ignoreNonTextNodeAttr","ignoreTextNodeAttr","ignoreNameSpace","ignoreRootElement","textNodeName","textNodeConversion","textAttrConversion","arrayMode"];
     for (var i = 0; i < props.length; i++) {
         if(options[props[i]] === undefined){
             options[props[i]] = defaultOptions[props[i]];
@@ -90,7 +91,7 @@ var getTraversalObj =function (xmlData,options){
 };
 
 var xml2json = function (xmlData,options){
-    return convertToJson(getTraversalObj(xmlData,options));
+    return convertToJson(getTraversalObj(xmlData,options), buildOptions(options).arrayMode);
 };
 
 var cdRegx = new RegExp("<!\\[CDATA\\[([^\\]\\]]*)\\]\\]>","g");
@@ -150,14 +151,14 @@ function buildAttributesArr(attrStr,ignore,prefix,ignoreNS,conversion){
     }
 }
 
-var convertToJson = function (node){
+var convertToJson = function (node, arrayMode){
     var jObj = {};
     if(node.val || node.val === "") {
         return node.val;
     }else{
         for (var index = 0; index < node.child.length; index++) {
             var prop = node.child[index].tagname;
-            var obj = convertToJson(node.child[index]);
+            var obj = convertToJson(node.child[index], arrayMode);
             if(jObj[prop] !== undefined){
                 if(!Array.isArray(jObj[prop])){
                     var swap = jObj[prop];
@@ -166,7 +167,7 @@ var convertToJson = function (node){
                 }
                 jObj[prop].push(obj);
             }else{
-                jObj[prop] = obj;
+                jObj[prop] = arrayMode ? [obj] : obj;
             }
         }
     }

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -24,12 +24,13 @@ var defaultOptions = {
     ignoreNameSpace : false,
     ignoreRootElement : false,
     textNodeConversion : true,
-    textAttrConversion : false
+    textAttrConversion : false,
+    arrayMode : false
 };
 
 var buildOptions = function (options){
     if(!options) options = {};
-    var props = ["attrPrefix","ignoreNonTextNodeAttr","ignoreTextNodeAttr","ignoreNameSpace","ignoreRootElement","textNodeName","textNodeConversion","textAttrConversion"];
+    var props = ["attrPrefix","ignoreNonTextNodeAttr","ignoreTextNodeAttr","ignoreNameSpace","ignoreRootElement","textNodeName","textNodeConversion","textAttrConversion","arrayMode"];
     for (var i = 0; i < props.length; i++) {
         if(options[props[i]] === undefined){
             options[props[i]] = defaultOptions[props[i]];
@@ -91,7 +92,7 @@ var getTraversalObj =function (xmlData,options){
 };
 
 var xml2json = function (xmlData,options){
-    return convertToJson(getTraversalObj(xmlData,options));
+    return convertToJson(getTraversalObj(xmlData,options), buildOptions(options).arrayMode);
 };
 
 var cdRegx = new RegExp("<!\\[CDATA\\[([^\\]\\]]*)\\]\\]>","g");
@@ -151,14 +152,14 @@ function buildAttributesArr(attrStr,ignore,prefix,ignoreNS,conversion){
     }
 }
 
-var convertToJson = function (node){
+var convertToJson = function (node, arrayMode){
     var jObj = {};
     if(node.val || node.val === "") {
         return node.val;
     }else{
         for (var index = 0; index < node.child.length; index++) {
             var prop = node.child[index].tagname;
-            var obj = convertToJson(node.child[index]);
+            var obj = convertToJson(node.child[index], arrayMode);
             if(jObj[prop] !== undefined){
                 if(!Array.isArray(jObj[prop])){
                     var swap = jObj[prop];
@@ -167,7 +168,7 @@ var convertToJson = function (node){
                 }
                 jObj[prop].push(obj);
             }else{
-                jObj[prop] = obj;
+                jObj[prop] = arrayMode ? [obj] : obj;
             }
         }
     }

--- a/spec/xmlParser_spec.js
+++ b/spec/xmlParser_spec.js
@@ -446,6 +446,60 @@ describe("XMLParser", function () {
         expect(result).toEqual(expected);
     });
 
+  it("should parse nodes as arrays", function () {
+    var fs = require("fs");
+    var path = require("path");
+    var fileNamePath = path.join(__dirname, "assets/simple.xml");
+    var xmlData = fs.readFileSync(fileNamePath).toString();
+
+    var expected = {
+      "any_name": [{
+        "@attr": ["https://example.com/somepath"],
+        "person": [{
+          "@id": ["101"],
+          "phone": [122233344550, 122233344551],
+          "name": ["Jack"],
+          "age": [33],
+          "emptyNode": [""],
+          "booleanNode": ["false", "true"],
+          "selfclosing": [
+            "",
+            {
+              "@with": "value"
+            }
+          ],
+          "married": [{
+            "@firstTime": "No",
+            "@attr": "val 2",
+            "#_text": "Yes"
+          }],
+          "birthday": ["Wed, 28 Mar 1979 12:13:14 +0300"],
+          "address": [{
+            "city": ["New York"],
+            "street": ["Park Ave"],
+            "buildingNo": [1],
+            "flatNo": [1]
+          }, {
+            "city": ["Boston"],
+            "street": ["Centre St"],
+            "buildingNo": [33],
+            "flatNo": [24]
+          }]
+        }]
+      }]
+    };
+
+    var result = parser.parse(xmlData, {
+      ignoreTextNodeAttr: false,
+      ignoreNonTextNodeAttr: false,
+      attrPrefix: "@",
+      textNodeName: "#_text",
+      arrayMode: true
+    });
+    //console.log(JSON.stringify(result,null,4));
+    expect(result).toEqual(expected);
+  });
+
     it("should intermediate traversable JS object which can later covert to JSON", function () {
         var xmlData = "<rootNode><tag></tag><tag>1</tag><tag>val</tag></rootNode>";
 


### PR DESCRIPTION
I migrated some code that parses SVGs from `xml2js` to `fast-xml-parser` and I found that, at one point, I needed to do the following:
```
const shapes = Array.isArray(svg[shapeType]) ? svg[shapeType] : [svg[shapeType]]
shapes.map(...)
```

With `xml2js` even when a shape node was just one, it was returned as an array and the check wasn’t needed.

I’m not sure if this is something you’d like to consider, but it helped in my case. I added a test case, too.