### PR TITLE
Correctly remove CRLF line breaks

### DIFF
--- a/bin/validator.js
+++ b/bin/validator.js
@@ -3,7 +3,7 @@ var util = require("./util");
 
 var tagsPattern = new RegExp("<\\/?([\\w:\\-_\.]+)\\s*\/?>","g");
 exports.validate = function(xmlData){
-    xmlData = xmlData.replace(/\n/g,"");//make it single line
+    xmlData = xmlData.replace(/(\r\n|\n|\r)/gm,"");//make it single line
     xmlData = xmlData.replace(/(^\s*<\?xml.*?\?>)/g,"");//Remove XML starting tag
     xmlData = xmlData.replace(/(<!DOCTYPE[\s\w\"\.\/\-\:]+(\[.*\])*\s*>)/g,"");//Remove DOCTYPE
 
@@ -12,9 +12,9 @@ exports.validate = function(xmlData){
 
         if(xmlData[i] === "<"){//starting of tag
             //read until you reach to '>' avoiding any '>' in attribute value
-            
+
             i++;
-            
+
             if(xmlData[i] === "!"){
                 i = readCommentAndCDATA(xmlData,i);
                 continue;
@@ -26,8 +26,8 @@ exports.validate = function(xmlData){
                 }
                 //read tagname
                 var tagName = "";
-                for(;i < xmlData.length 
-                    && xmlData[i] !== ">" 
+                for(;i < xmlData.length
+                    && xmlData[i] !== ">"
                     && xmlData[i] !== " "
                     && xmlData[i] !== "\t" ; i++) {
 
@@ -35,14 +35,14 @@ exports.validate = function(xmlData){
                 }
                 tagName = tagName.trim();
                 //console.log(tagName);
-                
+
                 if(tagName[tagName.length-1] === "/"){//self closing tag without attributes
                     tagName = tagName.substring(0,tagName.length-2);
                     return validateTagName(tagName);
                 }
                 if(!validateTagName(tagName)) return false;
 
-                
+
                 var attrStr = "";
                 var startChar = "";
                 for(;i < xmlData.length ;i++){
@@ -62,14 +62,14 @@ exports.validate = function(xmlData){
                 if(startChar !== "") return false;//Unclosed quote
                 attrStr = attrStr.trim();
                 //console.log(attrStr, attrStr);
-                
+
                 if(attrStr[attrStr.length-1] === "/" ){//self closing tag
                     attrStr = attrStr.substring(0,attrStr.length-2);
-                    
+
                     if(!validateAttributeString(attrStr)){
                         return false;
                     }else{
-                        
+
                         continue;
                     }
                 }else if(closingTag){
@@ -77,7 +77,7 @@ exports.validate = function(xmlData){
                         return false;
                         //throw new Error("XML validation error: closing tag should not have any attribute");
                     }else{
-                        var otg = tags.pop();    
+                        var otg = tags.pop();
                         if(tagName !== otg){
                             return false;
                             //throw new Error("XML validation error: no mathicng closing tag");
@@ -106,18 +106,18 @@ exports.validate = function(xmlData){
                 if(xmlData[i] === "<") i--;
             }
         }else{
-            
+
             if(xmlData[i] === " " || xmlData[i] === "\t") continue;
             return false;
         }
     }
 
-    
+
     if(tags.length > 0){
         return false;
         //throw new Error("XML validation error");
     }
-    
+
     return true;
 }
 
@@ -129,8 +129,8 @@ function readCommentAndCDATA(xmlData,i){
                 break;
             }
         }
-    }else if( xmlData.length > i+9 
-        && xmlData[i+1] === "[" 
+    }else if( xmlData.length > i+9
+        && xmlData[i+1] === "["
         && xmlData[i+2] === "C"
         && xmlData[i+3] === "D"
         && xmlData[i+4] === "A"
@@ -148,7 +148,7 @@ function readCommentAndCDATA(xmlData,i){
 
     return i;
 }
-//attr, ="sd", a="amit's", a="sd"b="saf", 
+//attr, ="sd", a="amit's", a="sd"b="saf",
 function validateAttributeString(attrStr){
     var attrNames = [];
     for(var i=0; i< attrStr.length; i++){
@@ -161,8 +161,8 @@ function validateAttributeString(attrStr){
         //validate attrName
         attrName = attrName.trim();
 
-        
-        
+
+
         if(!attrNames.hasOwnProperty(attrName)){
             attrNames[attrName]=1;
         }else{
@@ -172,20 +172,20 @@ function validateAttributeString(attrStr){
             return false;
         }
         i++;
-        
+
         //skip whitespaces
-        for(;i < attrStr.length 
+        for(;i < attrStr.length
             && (attrStr[i] === " "
             || attrStr[i] === "\t") ; i++);
 
         //read attribute value
         startChar = attrStr[i++];
-        
+
         var attrVal = "";
         for(;i < attrStr.length && attrStr[i] !== startChar; i++) {
             attrVal +=attrStr[i];
         }
-        
+
         //validate attrVal
 
         if(startChar !== ""){

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -243,7 +243,7 @@ var util = require("./util");
 
 var tagsPattern = new RegExp("<\\/?([\\w:\\-_\.]+)\\s*\/?>","g");
 exports.validate = function(xmlData){
-    xmlData = xmlData.replace(/\n/g,"");//make it single line
+    xmlData = xmlData.replace(/(\r\n|\n|\r)/gm,"");//make it single line
     xmlData = xmlData.replace(/(^\s*<\?xml.*?\?>)/g,"");//Remove XML starting tag
     xmlData = xmlData.replace(/(<!DOCTYPE[\s\w\"\.\/\-\:]+(\[.*\])*\s*>)/g,"");//Remove DOCTYPE
 
@@ -252,9 +252,9 @@ exports.validate = function(xmlData){
 
         if(xmlData[i] === "<"){//starting of tag
             //read until you reach to '>' avoiding any '>' in attribute value
-            
+
             i++;
-            
+
             if(xmlData[i] === "!"){
                 i = readCommentAndCDATA(xmlData,i);
                 continue;
@@ -266,8 +266,8 @@ exports.validate = function(xmlData){
                 }
                 //read tagname
                 var tagName = "";
-                for(;i < xmlData.length 
-                    && xmlData[i] !== ">" 
+                for(;i < xmlData.length
+                    && xmlData[i] !== ">"
                     && xmlData[i] !== " "
                     && xmlData[i] !== "\t" ; i++) {
 
@@ -275,14 +275,14 @@ exports.validate = function(xmlData){
                 }
                 tagName = tagName.trim();
                 //console.log(tagName);
-                
+
                 if(tagName[tagName.length-1] === "/"){//self closing tag without attributes
                     tagName = tagName.substring(0,tagName.length-2);
                     return validateTagName(tagName);
                 }
                 if(!validateTagName(tagName)) return false;
 
-                
+
                 var attrStr = "";
                 var startChar = "";
                 for(;i < xmlData.length ;i++){
@@ -302,14 +302,14 @@ exports.validate = function(xmlData){
                 if(startChar !== "") return false;//Unclosed quote
                 attrStr = attrStr.trim();
                 //console.log(attrStr, attrStr);
-                
+
                 if(attrStr[attrStr.length-1] === "/" ){//self closing tag
                     attrStr = attrStr.substring(0,attrStr.length-2);
-                    
+
                     if(!validateAttributeString(attrStr)){
                         return false;
                     }else{
-                        
+
                         continue;
                     }
                 }else if(closingTag){
@@ -317,7 +317,7 @@ exports.validate = function(xmlData){
                         return false;
                         //throw new Error("XML validation error: closing tag should not have any attribute");
                     }else{
-                        var otg = tags.pop();    
+                        var otg = tags.pop();
                         if(tagName !== otg){
                             return false;
                             //throw new Error("XML validation error: no mathicng closing tag");
@@ -346,18 +346,18 @@ exports.validate = function(xmlData){
                 if(xmlData[i] === "<") i--;
             }
         }else{
-            
+
             if(xmlData[i] === " " || xmlData[i] === "\t") continue;
             return false;
         }
     }
 
-    
+
     if(tags.length > 0){
         return false;
         //throw new Error("XML validation error");
     }
-    
+
     return true;
 }
 
@@ -369,8 +369,8 @@ function readCommentAndCDATA(xmlData,i){
                 break;
             }
         }
-    }else if( xmlData.length > i+9 
-        && xmlData[i+1] === "[" 
+    }else if( xmlData.length > i+9
+        && xmlData[i+1] === "["
         && xmlData[i+2] === "C"
         && xmlData[i+3] === "D"
         && xmlData[i+4] === "A"
@@ -388,7 +388,7 @@ function readCommentAndCDATA(xmlData,i){
 
     return i;
 }
-//attr, ="sd", a="amit's", a="sd"b="saf", 
+//attr, ="sd", a="amit's", a="sd"b="saf",
 function validateAttributeString(attrStr){
     var attrNames = [];
     for(var i=0; i< attrStr.length; i++){
@@ -401,8 +401,8 @@ function validateAttributeString(attrStr){
         //validate attrName
         attrName = attrName.trim();
 
-        
-        
+
+
         if(!attrNames.hasOwnProperty(attrName)){
             attrNames[attrName]=1;
         }else{
@@ -412,20 +412,20 @@ function validateAttributeString(attrStr){
             return false;
         }
         i++;
-        
+
         //skip whitespaces
-        for(;i < attrStr.length 
+        for(;i < attrStr.length
             && (attrStr[i] === " "
             || attrStr[i] === "\t") ; i++);
 
         //read attribute value
         startChar = attrStr[i++];
-        
+
         var attrVal = "";
         for(;i < attrStr.length && attrStr[i] !== startChar; i++) {
             attrVal +=attrStr[i];
         }
-        
+
         //validate attrVal
 
         if(startChar !== ""){

--- a/spec/assets/crlf.xml
+++ b/spec/assets/crlf.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+        <!DOCTYPE daily_western_horo_fr>
+        <daily_western_horo_fr>
+            <date valeur="2017-09-25"><signe valeur="balance">
+                        <nombre_chance>25
+                        </nombre_chance>
+                    </signe></date>
+        </daily_western_horo_fr>

--- a/spec/validator_spec.js
+++ b/spec/validator_spec.js
@@ -229,6 +229,16 @@ describe("XMLParser", function () {
         expect(result).toBe(true);
     });
 
+    it("should validate xml data with CRLF", function () {
+        var fs = require("fs");
+        var path = require("path");
+        var fileNamePath = path.join(__dirname, "assets/crlf.xml");
+        var xmlData = fs.readFileSync(fileNamePath).toString();
+
+        var result = validator.validate(xmlData);
+        expect(result).toBe(true);
+    });
+
     it("should return false for invalid xml", function () {
         var fs = require("fs");
         var path = require("path");


### PR DESCRIPTION
Related to https://github.com/NaturalIntelligence/fast-xml-parser/issues/36

In fact, the XML I retrieve from an external API has CRLF line break instead of just LF.
Your regex doesn't handle that case that's why the validator always return `false` (see https://stackoverflow.com/a/10805198/569101)