### PR TITLE
first draft of typings for typescript #69

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,5 +81,6 @@
   },
   "dependencies": {
     "nimnjs": "^1.2.2"
-  }
+  },
+  "typings": "src/parser.d.ts"
 }

--- a/src/parser.d.ts
+++ b/src/parser.d.ts
@@ -1,0 +1,64 @@
+type X2jOptions = {
+  attributeNamePrefix: string;
+  attrNodeName: false | string;
+  textNodeName: string;
+  ignoreAttributes: boolean;
+  ignoreNameSpace: boolean;
+  allowBooleanAttributes: boolean;
+  parseNodeValue: boolean;
+  parseAttributeValue: boolean;
+  arrayMode: boolean;
+  trimValues: boolean;
+  cdataTagName: false | string;
+  cdataPositionChar: string;
+  tagValueProcessor: (tagValue: string) => string;
+  attrValueProcessor: (attrValue: string) => string;
+};
+type X2jOptionsOptional = Partial<X2jOptions>;
+
+type J2xOptions = {
+  attributeNamePrefix: string;
+  attrNodeName: false | string;
+  textNodeName: string;
+  ignoreAttributes: boolean;
+  cdataTagName: false | string;
+  cdataPositionChar: string;
+  format: boolean;
+  indentBy: string;
+  supressEmptyNode: boolean;
+  tagValueProcessor: (tagValue: string) => string;
+  attrValueProcessor: (attrValue: string) => string;
+};
+type J2xOptionsOptional = Partial<J2xOptions>;
+
+type ESchema = string | Array | object;
+
+type ValidationError = {
+  err: { code: string; msg: string };
+};
+
+export function parse(xmlData: string, options?: X2jOptionsOptional): any;
+export function convert2nimn(
+  node: any,
+  e_schema: ESchema,
+  options?: X2jOptionsOptional
+): any;
+export function getTraversalObj(
+  xmlData: string,
+  options?: X2jOptionsOptional
+): any;
+export function convertToJson(node: any, options?: X2jOptionsOptional): any;
+export function convertToJsonString(
+  node: any,
+  options?: X2jOptionsOptional
+): string;
+export function validate(
+  xmlData: string,
+  options?: { allowBooleanAttributes?: boolean }
+): true | ValidationError;
+// export j2xParser ???
+export function parseToNimn(
+  xmlData: string,
+  schema,
+  options: Partial<X2jOptions>
+): any;


### PR DESCRIPTION
# Purpose / Goal
Some type definitions for external API, attempt to fix #69.

This PR doesn't change anything at runtime, it's only typing support for users use typescript.

It's not yet complete, but it is a start and better than nothing.

A different approach to create a separate typings file would be to convert the whole project to typescript. That would be a pretty big step and would also influence further development workflow, build process etc.

# Outlook
Besides filling the gaps of this type definitions, it might be interesting to provide a second signature to `parse` which takes a generic type. This could then be used as the return value.
Thus, when the developer knows that the parsed XML will be in a certain structure,
It might look something like this, but I didn't try it:
```javascript
export function parse(xmlData: string, options?: X2jOptionsOptional): any;
export function parse<T>(xmlData: string, options?: X2jOptionsOptional): T;
```
Usage would then be `parse<Whatever>(myXmlData)`. In this case, Typescript would know that the output is of type `Whatever` instead of any. Without this extra definition, a similar result can be achieved with `parse(myXmlData) as Whatever`. Neither of those has any runtime impact, it's just at development time. I'm not sure if it is good practice, so I left it out for now.

# Type

[ ]Bug Fix
[ ]Refactoring / Technology upgrade
[x]New Feature

