### PR TITLE
fix #84: Attribute selection logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,6 +125,9 @@
                     $('#result').text(e);
                 }
             });
+            
+            optionsLogic();
+            $('#ignoreAttributes').on('change', function (){optionsLogic();});
 
             function buildParsingConfig(){
                 var config = {
@@ -144,6 +147,20 @@
                 };
 
                 return config;
+            }
+            
+            function optionsLogic(){
+                var ignoreAttr = $('#ignoreAttributes').prop('checked');
+                if(ignoreAttr){
+                    $('#attrNodeName').prop('checked', !ignoreAttr);
+                    $('#ParseAttributeValue').prop('checked', !ignoreAttr);
+                    $('#allowBooleanAttributes').prop('checked', !ignoreAttr);
+                }
+                $('#attrNodeName').attr('disabled', ignoreAttr);
+                $('#ParseAttributeValue').attr('disabled', ignoreAttr);
+                $('#allowBooleanAttributes').attr('disabled', ignoreAttr);
+
+                return;
             }
         });
     </script>


### PR DESCRIPTION
# Purpose / Goal

When Ignore attributes from parsing is selected then following checkboxes should be disabled.

Group all the attributes as properties of given name.
Parse the value of an attribute to float or integer.
A tag can have attributes without any value.


# Type
Please mention the type of PR

[ ]Bug Fix
[ ]Refactoring / Technology upgrade
[ X ]New Feature

**Note** : Please ensure that you've read contribution [guidelines](https://github.com/NaturalIntelligence/fast-xml-parser/blob/master/CONTRIBUTING.md) before raising this PR.