### PR TITLE
fix #89,fix #90, fix #91 Refactored buildOptions, fixed bug with BOM and added support non-english characters in validator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fast-xml-parser",
-  "version": "3.9.11",
+  "version": "3.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/spec/validator_cyrillic_xml_spec.js
+++ b/spec/validator_cyrillic_xml_spec.js
@@ -1,0 +1,14 @@
+"use strict";
+
+const validator = require("../src/validator");
+
+describe("XMLParser", function() {
+
+    it("should validate xml string with cyrillic characters", function() {
+        const options = {localeRange: "a-zA-Zа-яёА-ЯЁ"}
+        let xmlData = "<?xml version=\"1.0\" encoding=\"utf-8\" ?><КорневаяЗапись><Тэг>ЗначениеValue53456</Тэг></КорневаяЗапись>";
+        let result = validator.validate(xmlData, options);
+        expect(result).toBe(true);
+
+    });
+});

--- a/spec/validator_utf8_with_BOM_spec.js
+++ b/spec/validator_utf8_with_BOM_spec.js
@@ -5,8 +5,9 @@ const validator = require("../src/validator");
 describe("XMLParser", function() {
 
     it("should validate xml string with cyrillic characters", function() {
+        const BOM = "\ufeff";
         const options = {localeRange: "a-zA-Zа-яёА-ЯЁ"}
-        let xmlData = "<?xml version=\"1.0\" encoding=\"utf-8\" ?><КорневаяЗапись><Тэг>ЗначениеValue53456</Тэг></КорневаяЗапись>";
+        let xmlData = BOM + "<?xml version=\"1.0\" encoding=\"utf-8\" ?><КорневаяЗапись><Тэг>ЗначениеValue53456</Тэг></КорневаяЗапись>";
         let result = validator.validate(xmlData, options);
         expect(result).toBe(true);
 

--- a/src/parser.d.ts
+++ b/src/parser.d.ts
@@ -11,6 +11,7 @@ type X2jOptions = {
   trimValues: boolean;
   cdataTagName: false | string;
   cdataPositionChar: string;
+  localeRange:  string;
   tagValueProcessor: (tagValue: string) => string;
   attrValueProcessor: (attrValue: string) => string;
 };

--- a/src/util.js
+++ b/src/util.js
@@ -64,9 +64,9 @@ exports.getValue = function(v) {
 exports.buildOptions = function(options,defaultOptions,props) {
     var newOptions = {};
     if (!options) {
-        options = {};
+        return defaultOptions; //if there are not options
     }
-    
+
     for (let i = 0; i < props.length; i++) {
         if ( options[props[i]] !== undefined) {
             newOptions[props[i]] = options[props[i]];

--- a/src/validator.js
+++ b/src/validator.js
@@ -22,8 +22,8 @@ exports.validate = function(xmlData, options) {
     if (xmlData[0] === "\ufeff") {
       xmlData = xmlData.substr(1);
     }
-    const regxAttrName = new RegExp("^[_\\w][\\w\\-.:]*$".replace(/_\\w/g, "_" + options.localeRange));
-    const regxTagName = new RegExp("^([\\w]|_)[\\w.\\-_:]*".replace(/\(\[\\w/g, "([" + options.localeRange));
+    const regxAttrName = new RegExp("^[_w][\\w\\-.:]*$".replace("_w", "_" + options.localeRange));
+    const regxTagName = new RegExp("^([w]|_)[\\w.\\-_:]*".replace("([w", "([" + options.localeRange));
     for (let i = 0; i < xmlData.length; i++) {
 
         if (xmlData[i] === "<") {//starting of tag

--- a/src/validator.js
+++ b/src/validator.js
@@ -22,8 +22,8 @@ exports.validate = function(xmlData, options) {
     if (xmlData[0] === "\ufeff") {
       xmlData = xmlData.substr(1);
     }
-    const regxAttrName = "^[_\\w][\\w\\-.:]*$".replace(/_\\w/g, "_" + options.localeRange);
-    const regxTagName = "^([\\w]|_)[\\w.\\-_:]*".replace(/\(\[\\w/g, "([" + options.localeRange);
+    const regxAttrName = new RegExp("^[_\\w][\\w\\-.:]*$".replace(/_\\w/g, "_" + options.localeRange));
+    const regxTagName = new RegExp("^([\\w]|_)[\\w.\\-_:]*".replace(/\(\[\\w/g, "([" + options.localeRange));
     for (let i = 0; i < xmlData.length; i++) {
 
         if (xmlData[i] === "<") {//starting of tag
@@ -281,8 +281,8 @@ function validateAttributeString(attrStr, options, regxAttrName) {
 // const validAttrRegxp = /^[_a-zA-Z][\w\-.:]*$/;
 
 function validateAttrName(attrName, regxAttrName) {
-    const validAttrRegxp = new RegExp(regxAttrName);
-    return util.doesMatch(attrName, validAttrRegxp);
+    // const validAttrRegxp = new RegExp(regxAttrName);
+    return util.doesMatch(attrName, regxAttrName);
 }
 
 //const startsWithXML = new RegExp("^[Xx][Mm][Ll]");
@@ -291,6 +291,5 @@ function validateAttrName(attrName, regxAttrName) {
 function validateTagName(tagname, regxTagName) {
     /*if(util.doesMatch(tagname,startsWithXML)) return false;
     else*/
-    const startsWith = new RegExp(regxTagName);
-    return !util.doesNotMatch(tagname, startsWith);
+    return !util.doesNotMatch(tagname, regxTagName);
 }

--- a/src/validator.js
+++ b/src/validator.js
@@ -3,10 +3,11 @@
 const util = require("./util");
 
 const defaultOptions = {
-    allowBooleanAttributes: false         //A tag can have attributes without any value
+    allowBooleanAttributes: false,         //A tag can have attributes without any value
+    localeRange:  "a-zA-Z"
 };
 
-const props = ["allowBooleanAttributes"];
+const props = ["allowBooleanAttributes", "localeRange"];
 
 //const tagsPattern = new RegExp("<\\/?([\\w:\\-_\.]+)\\s*\/?>","g");
 exports.validate = function(xmlData, options) {
@@ -18,6 +19,8 @@ exports.validate = function(xmlData, options) {
 
     const tags = [];
     let tagFound = false;
+    const regxAttrName = "^[_\\w][\\w\\-.:]*$".replace(/_\\w/g, "_" + options.localeRange);
+    const regxTagName = "^([\\w]|_)[\\w.\\-_:]*".replace(/\(\[\\w/g, "([" + options.localeRange);
     for (let i = 0; i < xmlData.length; i++) {
 
         if (xmlData[i] === "<") {//starting of tag
@@ -54,7 +57,7 @@ exports.validate = function(xmlData, options) {
                     tagName = tagName.substring(0, tagName.length - 1);
                     continue;
                 }
-                if (!validateTagName(tagName)) {
+                if (!validateTagName(tagName, regxTagName)) {
                     return {err: {code: "InvalidTag", msg: "Tag " + tagName + " is an invalid name."}};
                 }
 
@@ -67,7 +70,7 @@ exports.validate = function(xmlData, options) {
 
                 if (attrStr[attrStr.length - 1] === "/") {//self closing tag
                     attrStr = attrStr.substring(0, attrStr.length - 1);
-                    const isValid = validateAttributeString(attrStr, options);
+                    const isValid = validateAttributeString(attrStr, options, regxAttrName);
                     if (isValid === true) {
                         tagFound = true;
                         continue;
@@ -84,7 +87,7 @@ exports.validate = function(xmlData, options) {
                         }
                     }
                 } else {
-                    const isValid = validateAttributeString(attrStr, options);
+                    const isValid = validateAttributeString(attrStr, options, regxAttrName);
                     if (isValid !== true) {
                         return isValid;
                     }
@@ -238,7 +241,7 @@ const validAttrStrRegxp = new RegExp("(\\s*)([^\\s=]+)(\\s*=)?(\\s*(['\"])(([\\s
 
 //attr, ="sd", a="amit's", a="sd"b="saf", ab  cd=""
 
-function validateAttributeString(attrStr, options) {
+function validateAttributeString(attrStr, options, regxAttrName) {
     //console.log("start:"+attrStr+":end");
 
     //if(attrStr.trim().length === 0) return true; //empty string
@@ -258,7 +261,7 @@ function validateAttributeString(attrStr, options) {
                     return { err: { code:"InvalidAttr",msg:"attribute " + matches[i][2] + " has no value assigned."}};
                 } */
         const attrName = matches[i][2];
-        if (!validateAttrName(attrName)) {
+        if (!validateAttrName(attrName, regxAttrName)) {
             return {err: {code: "InvalidAttr", msg: "attribute " + attrName + " is an invalid name."}};
         }
         if (!attrNames.hasOwnProperty(attrName)) {//check for duplicate attribute.
@@ -272,19 +275,19 @@ function validateAttributeString(attrStr, options) {
 
 }
 
-const validAttrRegxp = /^[_a-zA-Z][\w\-.:]*$/;
+// const validAttrRegxp = /^[_a-zA-Z][\w\-.:]*$/;
 
-function validateAttrName(attrName) {
+function validateAttrName(attrName, regxAttrName) {
+    const validAttrRegxp = new RegExp(regxAttrName);
     return util.doesMatch(attrName, validAttrRegxp);
 }
 
 //const startsWithXML = new RegExp("^[Xx][Mm][Ll]");
-const startsWith = /^([a-zA-Z]|_)[\w.\-_:]*/;
+//  startsWith = /^([a-zA-Z]|_)[\w.\-_:]*/;
 
-function validateTagName(tagname) {
+function validateTagName(tagname, regxTagName) {
     /*if(util.doesMatch(tagname,startsWithXML)) return false;
     else*/
+    const startsWith = new RegExp(regxTagName);
     return !util.doesNotMatch(tagname, startsWith);
 }
-
-

--- a/src/validator.js
+++ b/src/validator.js
@@ -19,14 +19,14 @@ exports.validate = function(xmlData, options) {
 
     const tags = [];
     let tagFound = false;
-    if (xmlData[0] === "\ufeff") {
+    if (xmlData[0] === "\ufeff") {  // check for byte order mark (BOM)
       xmlData = xmlData.substr(1);
     }
     const regxAttrName = new RegExp("^[_w][\\w\\-.:]*$".replace("_w", "_" + options.localeRange));
     const regxTagName = new RegExp("^([w]|_)[\\w.\\-_:]*".replace("([w", "([" + options.localeRange));
     for (let i = 0; i < xmlData.length; i++) {
 
-        if (xmlData[i] === "<") {//starting of tag
+        if (xmlData[i] === "<") { //starting of tag
             //read until you reach to '>' avoiding any '>' in attribute value
 
             i++;

--- a/src/validator.js
+++ b/src/validator.js
@@ -19,6 +19,9 @@ exports.validate = function(xmlData, options) {
 
     const tags = [];
     let tagFound = false;
+    if (xmlData[0] === "\ufeff") {
+      xmlData = xmlData.substr(1);
+    }
     const regxAttrName = "^[_\\w][\\w\\-.:]*$".replace(/_\\w/g, "_" + options.localeRange);
     const regxTagName = "^([\\w]|_)[\\w.\\-_:]*".replace(/\(\[\\w/g, "([" + options.localeRange);
     for (let i = 0; i < xmlData.length; i++) {


### PR DESCRIPTION
# Purpose / Goal
Corrected returning value defaultOptions in buildOptions function instead of set every newOptions from defaultOptions in loop when there are not user's options. I think it give a little bit rise of perfomance (fix #89). Fixed bug in validation when XML data with byte order marker (BOM) (fix #90). Added support of non-english characters in XML validation (fix #91).

# Type
Enhancement, refactoring, bug fix

[x]Bug Fix
[x]Refactoring / Technology upgrade
[x]New Feature
