### PR TITLE
added missing TypeScript definition for j2xParser

### DIFF
--- a/src/parser.d.ts
+++ b/src/parser.d.ts
@@ -57,7 +57,10 @@ export function validate(
   xmlData: string,
   options?: { allowBooleanAttributes?: boolean }
 ): true | ValidationError;
-// export j2xParser ???
+export class j2xParser {
+  constructor(options: J2xOptionsOptional);
+  parse(options: any);
+}
 export function parseToNimn(
   xmlData: string,
   schema: any,


### PR DESCRIPTION
# Purpose / Goal
Currently the usage of fast-xml-parser with TypeScript is only limited when converting JSON into XML. This is because the TypeScript definition of j2xParser is missing. This PR adds the missing definition.

# Type
[X]Bug Fix
[   ]Refactoring / Technology upgrade
[   ]New Feature
