### PR TITLE
Give j2xParser parse() method a return type annotation

### DIFF
--- a/src/parser.d.ts
+++ b/src/parser.d.ts
@@ -59,7 +59,7 @@ export function validate(
 ): true | ValidationError;
 export class j2xParser {
   constructor(options: J2xOptionsOptional);
-  parse(options: any);
+  parse(options: any): any;
 }
 export function parseToNimn(
   xmlData: string,


### PR DESCRIPTION
```
node_modules/fast-xml-parser/src/parser.d.ts:62:3 - error TS7010: 'parse', which lacks return-type annotation, implicitly has an 'any' return type.

62   parse(options: any);
     ~~~~~
```

[x]Bug Fix
[ ]Refactoring / Technology upgrade
[ ]New Feature
