### PR TITLE
fix invalid whitespace inside xml tag when format option is true and nodes have attr text

### DIFF
--- a/src/json2xml.js
+++ b/src/json2xml.js
@@ -168,7 +168,7 @@ function replaceCDATAarr(str, cdata) {
 function buildObjectNode(val, key, attrStr, level) {
     return this.indentate(level)
            + "<" + key + attrStr
-           + this.tagEndChar
+           + ">"
            + val
            //+ this.newLine
            + this.indentate(level)


### PR DESCRIPTION
… building object nodes with options.format === true

# Purpose / Goal
Please specify here what you're planning to achieve by this pull request and how it can help in regard of this work-space. 

If it is a bug fix, please mention the issue number. If there is no issue has been raised but the PR directly then it should follow the template given to raise the issue. Like input, expected output, actual output etc.


# Type
Please mention the type of PR

[ ]Bug Fix
[ ]Refactoring / Technology upgrade
[ ]New Feature

**Note** : Please ensure that you've read contribution [guidelines](https://github.com/NaturalIntelligence/fast-xml-parser/blob/master/CONTRIBUTING.md) before raising this PR.
