### PR TITLE
Fix formatting for nodes with attributes

### DIFF
--- a/src/json2xml.js
+++ b/src/json2xml.js
@@ -168,7 +168,7 @@ function replaceCDATAarr(str, cdata) {
 function buildObjectNode(val, key, attrStr, level) {
     return this.indentate(level)
            + "<" + key + attrStr
-           + this.tagEndChar
+           + ">"
            + val
            //+ this.newLine
            + this.indentate(level)

--- a/src/json2xml.js
+++ b/src/json2xml.js
@@ -166,13 +166,23 @@ function replaceCDATAarr(str, cdata) {
 }
 
 function buildObjectNode(val, key, attrStr, level) {
+  if (attrStr) {
     return this.indentate(level)
-           + "<" + key + attrStr
-           + ">"
-           + val
-           //+ this.newLine
-           + this.indentate(level)
-           + "</" + key + this.tagEndChar;
+          + "<" + key + attrStr
+          + ">"
+          + val
+          //+ this.newLine
+          // + this.indentate(level)
+          + "</" + key + this.tagEndChar;
+  } else {
+    return this.indentate(level)
+          + "<" + key + attrStr
+          + this.tagEndChar
+          + val
+          //+ this.newLine
+          + this.indentate(level)
+          + "</" + key + this.tagEndChar;
+  }
 }
 
 function buildEmptyObjNode(val, key, attrStr, level) {


### PR DESCRIPTION
# Purpose / Goal
I would like to fix a bug that I encountered when parsing json to xml with the format option flag set to true. If the JSON doc specifies nodes with an attr string and text value, an extra newline is added between the > of the open tag and the node text value, and extra whitespace is added to the end of the text value equal to n * level (where n is the number of spaces in indentBy, default 2).

https://github.com/NaturalIntelligence/fast-xml-parser/issues/104

# Type
Please mention the type of PR

[X]Bug Fix
[ ]Refactoring / Technology upgrade
[ ]New Feature

**Note** : Please ensure that you've read contribution [guidelines](https://github.com/NaturalIntelligence/fast-xml-parser/blob/master/CONTRIBUTING.md) before raising this PR.
