### PR TITLE
Adding lib/parser.js to package.json to fix CLI tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,11 @@
 {
   "name": "fast-xml-parser",
-  "version": "3.12.0",
+  "version": "3.12.1",
   "description": "Validate XML or Parse XML to JS/JSON very fast without C/C++ based libraries",
   "main": "./src/parser.js",
+  "files": [
+    "./lib/parser.js"
+  ],
   "scripts": {
     "test": "jasmine spec/*spec.js",
     "perf": "node ./benchmark/perfTest3.js",


### PR DESCRIPTION
# Purpose / Goal
Fix for issue #112: CLI tools won't work unless `lib/parser.js` is included when installing `fast-xml-parser`.

# Type
[x]Bug Fix
[ ]Refactoring / Technology upgrade
[ ]New Feature
