### PR TITLE
Pass validation if XML contains 'length' attribute

### DIFF
--- a/spec/validator_spec.js
+++ b/spec/validator_spec.js
@@ -361,13 +361,13 @@ describe("XMLParser", function() {
         const result = validator.validate(xmlData).err;
         expect(result).toEqual(expected);
     });
-    
+
     it("should validate XML PIs", function () {
         var xmlData = '<?xml version="1.0"?>'
         +'<?mso-contentType?>'
         +'<h1></h1>'
         +'<?mso-contentType something="val"?>';
-        
+
         var result = validator.validate(xmlData);
         expect(result).toBe(true);
     });
@@ -379,11 +379,24 @@ describe("XMLParser", function() {
         +'<?mso-contentType something="val"?>';
 
         var expected = { code: 'InvalidChar', msg: 'char " is not expected .' }
-        
+
         var result = validator.validate(xmlData).err;
         expect(result).toEqual(expected);
     });
 
+    it('should validate xml with a "length" attribute', function() {
+        const xmlData = '<name length="1"></name>';
+
+        var result = validator.validate(xmlData);
+        expect(result).toEqual(true);
+    });
+
+    it("should not validate xml with repeated attributes", function() {
+        const xmlData = '<name length="bar" length="baz"></name>';
+
+        var expected = { code: 'InvalidAttr', msg: 'attribute length is repeated.' }
+
+        var result = validator.validate(xmlData).err;
+        expect(result).toEqual(expected);
+    });
 });
-
-

--- a/src/validator.js
+++ b/src/validator.js
@@ -250,7 +250,7 @@ function validateAttributeString(attrStr, options, regxAttrName) {
     //if(attrStr.trim().length === 0) return true; //empty string
 
     const matches = util.getAllMatches(attrStr, validAttrStrRegxp);
-    const attrNames = [];
+    const attrNames = {};
 
     for (let i = 0; i < matches.length; i++) {
         //console.log(matches[i]);


### PR DESCRIPTION
# Purpose / Goal
Bugfix for #129 

When validating XML containing a 'length' attribute currently an error is always returned 'attribute length is repeated.'. 

This is because the code uses an array to check for repeated attributes and calls hasOwnProperty('length'). I have changed this to use an object instead of an array so hasOwnProperty('length') will only return true when there are multiple length attributes. The test I have added verifies this.

# Type

[x]Bug Fix
[ ]Refactoring / Technology upgrade
[ ]New Feature

Benchmark results:

```
❯ node benchmark/perfTest3.js
Running Suite: XML Parser benchmark
validation : 15075.528720836128 requests/second
xml to json : 13612.412033517821 requests/second
xml to json + json string : 12826.365584690317 requests/second
xml to json string : 2125.6406392103368 requests/second
xml2js  : 5101.253171761319 requests/second
```
