### PR TITLE
fix for localeRange option in validator

### DIFF
--- a/src/validator.js
+++ b/src/validator.js
@@ -22,7 +22,7 @@ exports.validate = function(xmlData, options) {
     if (xmlData[0] === "\ufeff") {  // check for byte order mark (BOM)
       xmlData = xmlData.substr(1);
     }
-    const regxAttrName = new RegExp("^[_w][\\w\\-.:]*$".replace("_w", "_" + options.localeRange));
+    const regxAttrName = new RegExp("^[_w][\\w\\-.:]*$".replace("w", options.localeRange));
     const regxTagName = new RegExp("^([w]|_)[\\w.\\-_:]*".replace("([w", "([" + options.localeRange));
     for (let i = 0; i < xmlData.length; i++) {
 


### PR DESCRIPTION
# Purpose / Goal
There was an error where the localeRange option of the validate function only matched the start of the attribute name

<!-- If it is a bug fix, please mention the issue number. If there is no issue has been raised but the PR directly then it should follow the template given to raise the issue. Like input, expected output, actual output etc. -->


# Type
Please mention the type of PR
<!-- choose one by changing [ ] to [x] -->
* [x]Bug Fix
* [ ]Refactoring / Technology upgrade
* [ ]New Feature
