### PR TITLE
Support a new option "stopNodes".

### DIFF
--- a/spec/stopNodes_spec.js
+++ b/spec/stopNodes_spec.js
@@ -55,7 +55,33 @@ describe("XMLParser", function() {
         expect(result).toBe(true);
     });
 
-    it("2. stop node has nothing in it", function() {
+  it("1c. have two stopNodes, one within the other", function() {
+    const xmlData = `<issue><title>test 1</title><fix1 lang="en"><p>p 1</p><fix2><p>p 2</p><div class="show">div 2</div></fix2><div class="show">div 1</div></fix1></issue>`;
+    const expected = {
+      "issue": {
+        "title": "test 1",
+        "fix1": {
+          "#text": "<p>p 1</p><fix2><p>p 2</p><div class=\"show\">div 2</div></fix2><div class=\"show\">div 1</div>",
+          "lang": "en"
+        }
+      }
+    };
+
+    let result = parser.parse(xmlData, {
+      attributeNamePrefix: "",
+      ignoreAttributes:    false,
+      parseAttributeValue: true,
+      stopNodes: ["fix1", "fix2"]
+    });
+
+    //console.log(JSON.stringify(result,null,4));
+    expect(result).toEqual(expected);
+
+    result = validator.validate(xmlData);
+    expect(result).toBe(true);
+  });
+
+    it("2a. stop node has nothing in it", function() {
         const xmlData = `<issue><title>test 1</title><fix1></fix1></issue>`;
         const expected = {
             "issue": {
@@ -77,6 +103,29 @@ describe("XMLParser", function() {
         result = validator.validate(xmlData);
         expect(result).toBe(true);
     });
+
+  it("2b. stop node is self-closing", function() {
+    const xmlData = `<issue><title>test 1</title><fix1/></issue>`;
+    const expected = {
+      "issue": {
+        "title": "test 1",
+        "fix1": ""
+      }
+    };
+
+    let result = parser.parse(xmlData, {
+      attributeNamePrefix: "",
+      ignoreAttributes:    false,
+      parseAttributeValue: true,
+      stopNodes: ["fix1", "fix2"]
+    });
+
+    //console.log(JSON.stringify(result,null,4));
+    expect(result).toEqual(expected);
+
+    result = validator.validate(xmlData);
+    expect(result).toBe(true);
+  });
 
     it("4. cdata", function() {
         const xmlData = `<?xml version='1.0'?>

--- a/spec/stopNodes_spec.js
+++ b/spec/stopNodes_spec.js
@@ -1,0 +1,138 @@
+"use strict";
+
+const parser = require("../src/parser");
+const validator = require("../src/validator");
+const he = require("he");
+
+describe("XMLParser", function() {
+    it("1a. should support single stopNode", function() {
+        const xmlData = `<issue><title>test 1</title><fix1><p>p 1</p><div class="show">div 1</div></fix1></issue>`;
+        const expected = {
+            "issue": {
+                "title": "test 1",
+                "fix1": "<p>p 1</p><div class=\"show\">div 1</div>"
+            }
+        };
+
+        let result = parser.parse(xmlData, {
+            attributeNamePrefix: "",
+            ignoreAttributes:    false,
+            parseAttributeValue: true,
+            stopNodes: ["fix1"]
+        });
+
+        //console.log(JSON.stringify(result,null,4));
+        expect(result).toEqual(expected);
+
+        result = validator.validate(xmlData);
+        expect(result).toBe(true);
+    });
+
+    it("1b. 3. should support more than one stopNodes, with or without attr", function() {
+        const xmlData = `<issue><title>test 1</title><fix1 lang="en"><p>p 1</p><div class="show">div 1</div></fix1><fix2><p>p 2</p><div class="show">div 2</div></fix2></issue>`;
+        const expected = {
+            "issue": {
+				"title": "test 1",
+				"fix1": {
+					"#text": "<p>p 1</p><div class=\"show\">div 1</div>",
+					"lang": "en"
+				},
+				"fix2": "<p>p 2</p><div class=\"show\">div 2</div>"
+			}
+        };
+
+        let result = parser.parse(xmlData, {
+            attributeNamePrefix: "",
+            ignoreAttributes:    false,
+            parseAttributeValue: true,
+            stopNodes: ["fix1", "fix2"]
+        });
+
+        //console.log(JSON.stringify(result,null,4));
+        expect(result).toEqual(expected);
+
+        result = validator.validate(xmlData);
+        expect(result).toBe(true);
+    });
+
+    it("2. stop node has nothing in it", function() {
+        const xmlData = `<issue><title>test 1</title><fix1></fix1></issue>`;
+        const expected = {
+            "issue": {
+				"title": "test 1",
+				"fix1": ""
+			}
+        };
+
+        let result = parser.parse(xmlData, {
+            attributeNamePrefix: "",
+            ignoreAttributes:    false,
+            parseAttributeValue: true,
+            stopNodes: ["fix1", "fix2"]
+        });
+
+        //console.log(JSON.stringify(result,null,4));
+        expect(result).toEqual(expected);
+
+        result = validator.validate(xmlData);
+        expect(result).toBe(true);
+    });
+
+    it("4. cdata", function() {
+        const xmlData = `<?xml version='1.0'?>
+<issue>
+    <fix1>
+        <phone>+122233344550</phone>
+        <fix2><![CDATA[<fix1>Jack</fix1>]]><![CDATA[Jack]]></fix2>
+        <name><![CDATA[<some>Mohan</some>]]></name>
+        <blank><![CDATA[]]></blank>
+        <regx><![CDATA[^[ ].*$]]></regx>
+    </fix1>
+    <fix2>
+		<![CDATA[<some>Mohan</some>]]>
+	</fix2>
+</issue>`;
+        const expected = {
+            "issue": {
+				"fix1": "\n        <phone>+122233344550</phone>\n        <fix2><![CDATA[<fix1>Jack</fix1>]]><![CDATA[Jack]]></fix2>\n        <name><![CDATA[<some>Mohan</some>]]></name>\n        <blank><![CDATA[]]></blank>\n        <regx><![CDATA[^[ ].*$]]></regx>\n    ",
+				"fix2": "\n\t\t<![CDATA[<some>Mohan</some>]]>\n\t"
+			}
+        };
+
+        let result = parser.parse(xmlData, {
+            attributeNamePrefix:    "",
+            ignoreAttributes:       false,
+            parseAttributeValue:    true,
+            stopNodes: ["fix1", "fix2"]
+        });
+
+        //console.log(JSON.stringify(result,null,4));
+        expect(result).toEqual(expected);
+
+        result = validator.validate(xmlData, {
+            allowBooleanAttributes: true
+        });
+        expect(result).toBe(true);
+    });
+
+    it("5. stopNode at root level", function() {
+        const xmlData = `<fix1><p>p 1</p><div class="show">div 1</div></fix1>`;
+        const expected = {
+            "fix1": "<p>p 1</p><div class=\"show\">div 1</div>"
+        };
+
+        let result = parser.parse(xmlData, {
+            attributeNamePrefix: "",
+            ignoreAttributes:    false,
+            stopNodes: ["fix1", "fix2"]
+        });
+
+        //console.log(JSON.stringify(result,null,4));
+        expect(result).toEqual(expected);
+
+        result = validator.validate(xmlData, {
+            allowBooleanAttributes: true
+        });
+        expect(result).toBe(true);
+    });
+});

--- a/src/xmlstr2xmlnode.js
+++ b/src/xmlstr2xmlnode.js
@@ -86,10 +86,10 @@ const getTraversalObj = function(xmlData, options) {
       if (currentNode.parent && tag[14]) {
         currentNode.parent.val = util.getValue(currentNode.parent.val) + '' + processTagValue(tag[14], options);
       }
-      if (options.stopNodes && options.stopNodes.includes(currentNode.tagname)) {
+      if (options.stopNodes.length && options.stopNodes.includes(currentNode.tagname)) {
         currentNode.child = []
         if (currentNode.attrsMap == undefined) { currentNode.attrsMap = {}}
-        currentNode.val = xmlData.substr(currentNode.startIndex, tag.index - currentNode.startIndex)
+        currentNode.val = xmlData.substr(currentNode.startIndex + 1, tag.index - currentNode.startIndex - 1)
       }
       currentNode = currentNode.parent;
     } else if (tagType === TagType.CDATA) {
@@ -125,7 +125,7 @@ const getTraversalObj = function(xmlData, options) {
         currentNode,
         processTagValue(tag[14], options)
       );
-      if (options.stopNodes && options.stopNodes.includes(childNode.tagname)) {
+      if (options.stopNodes.length && options.stopNodes.includes(childNode.tagname)) {
         childNode.startIndex=tag.index + tag[1].length
       }
       childNode.attrsMap = buildAttributesMap(tag[8], options);

--- a/src/xmlstr2xmlnode.js
+++ b/src/xmlstr2xmlnode.js
@@ -39,6 +39,7 @@ const defaultOptions = {
   attrValueProcessor: function(a) {
     return a;
   },
+  stopNodes: []
   //decodeStrict: false,
 };
 
@@ -61,6 +62,7 @@ const props = [
   'tagValueProcessor',
   'attrValueProcessor',
   'parseTrueNumberOnly',
+  'stopNodes'
 ];
 exports.props = props;
 
@@ -84,7 +86,11 @@ const getTraversalObj = function(xmlData, options) {
       if (currentNode.parent && tag[14]) {
         currentNode.parent.val = util.getValue(currentNode.parent.val) + '' + processTagValue(tag[14], options);
       }
-
+      if (options.stopNodes && options.stopNodes.includes(currentNode.tagname)) {
+        currentNode.child = []
+        if (currentNode.attrsMap == undefined) { currentNode.attrsMap = {}}
+        currentNode.val = xmlData.substr(currentNode.startIndex, tag.index - currentNode.startIndex)
+      }
       currentNode = currentNode.parent;
     } else if (tagType === TagType.CDATA) {
       if (options.cdataTagName) {
@@ -119,6 +125,9 @@ const getTraversalObj = function(xmlData, options) {
         currentNode,
         processTagValue(tag[14], options)
       );
+      if (options.stopNodes && options.stopNodes.includes(childNode.tagname)) {
+        childNode.startIndex=tag.index + tag[1].length
+      }
       childNode.attrsMap = buildAttributesMap(tag[8], options);
       currentNode.addChild(childNode);
       currentNode = childNode;


### PR DESCRIPTION
This field is an array with 0 or more tagnames. When it encounters a tagname that matches the list of stopNodes, it will treat all the stuff understand this tag as a string.


# Purpose / Goal
This is used to support the parsing of certain xml documents where some nodes, such as <description> contains a xhtml structure. We need to treat it as a string and pass it to calling entity.
