### PR TITLE
fixed attribute name for nested node

### DIFF
--- a/src/json2xml.js
+++ b/src/json2xml.js
@@ -36,7 +36,7 @@ const props = [
 
 function Parser(options) {
   this.options = buildOptions(options, defaultOptions, props);
-  if (this.options.ignoreAttributes || this.options.attrNodeName) {
+  if (this.options.ignoreAttributes && this.options.attrNodeName) {
     this.isAttribute = function(/*a*/) {
       return false;
     };
@@ -148,7 +148,8 @@ Parser.prototype.j2x = function(jObj, level) {
         const Ks = Object.keys(jObj[key]);
         const L = Ks.length;
         for (let j = 0; j < L; j++) {
-          attrStr += ' ' + Ks[j] + '="' + this.options.attrValueProcessor('' + jObj[key][Ks[j]]) + '"';
+          const attr = this.isAttribute(Ks[j]);
+          attrStr += ' ' + attr + '="' + this.options.attrValueProcessor('' + jObj[key][Ks[j]]) + '"';
         }
       } else {
         const result = this.j2x(jObj[key], level + 1);


### PR DESCRIPTION
# Purpose / Goal

I tried j2x parser.
It found nested node is not been adapted option name `attrNodeName`.

I fixed this problem.
Please check it.

Thank you.

# Type
Please mention the type of PR
* [x]Bug Fix
* [ ]Refactoring / Technology upgrade
* [ ]New Feature