### PR TITLE
ValidateOnly now returns exitCode 1 when validation errors are found

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -59,6 +59,7 @@ if (process.argv[2] === '--help' || process.argv[2] === '-h') {
       }
     } else if (validateOnly) {
       output = parser.validate(xmlData);
+      process.exitCode = output === true ? 0 : 1;
     } else {
       output = JSON.stringify(parser.parse(xmlData, options), null, 4);
     }


### PR DESCRIPTION
# Purpose / Goal
I'd like to use the fast-xml-parser as a pre-commit hook in a project. Currently, the cli only returns exitCode of 0, by making this change, the pre-commit hook fails and forces the user to make the corresponding changes. I don't see any tests for the cli currently so I didn't add one for this PR.

Benchmark results:
node benchmark\perfTest3.js
Running Suite: XML Parser benchmark
validation : 10701.291345251915 requests/second
xml to json : 9646.121693327514 requests/second
xml to json + json string : 7912.822290970307 requests/second
xml to json string : 1179.1563269883957 requests/second
xml2js  : 3074.7737447301733 requests/second


# Type
Please mention the type of PR
<!-- choose one by changing [ ] to [x] -->
* [ ]Bug Fix
* [ ]Refactoring / Technology upgrade
* [x]New Feature

**Note** : Please ensure that you've read contribution [guidelines](https://github.com/NaturalIntelligence/fast-xml-parser/blob/master/CONTRIBUTING.md) before raising this PR.

[Bookmark](https://github.com/NaturalIntelligence/fast-xml-parser/stargazers) this repository for further updates.
