### PR TITLE
Implement a way of parsing xml to closely resemble that of xml.

### DIFF
--- a/spec/resembleXml_spec.js
+++ b/spec/resembleXml_spec.js
@@ -1,0 +1,101 @@
+"use strict";
+
+const parser = require("../src/parser");
+const validator = require("../src/validator");
+const he = require("he");
+
+describe("XMLParser", function() {
+    it("1. support parsing from xml to json with resembleXml mode", function() {
+        const xmlData = `<issue i1="i1v"><title t1="t1v">test 1</title></issue>`;
+        const expected = {
+          "nodeName": "issue",
+          "attr": {
+            "i1": "i1v"
+          },
+          "children": [
+            {
+              "nodeName": "title",
+              "attr": {
+                "t1": "t1v"
+              },
+              "val": "test 1"
+            }
+          ]
+        };
+
+        let result = parser.parse(xmlData, {
+            attributeNamePrefix: "",
+            ignoreAttributes:    false,
+            attrNodeName: "attr",
+            parseAttributeValue: true,
+            resembleXml: true
+        });
+        //console.log(JSON.stringify(result,null,4));
+        expect(result).toEqual(expected);
+        });
+
+  it("2. support parsing from xml to json with resembleXml mode and stopNode", function() {
+    const xmlData = `<issue><title>test 1</title><fix1><p>p 1</p><div class="show">div 1</div></fix1></issue>`;
+    const expected = {
+      "nodeName": "issue",
+      "children": [
+        {
+          "nodeName": "title",
+          "val": "test 1"
+        },
+        {
+          "nodeName": "fix1",
+          "val": "<p>p 1</p><div class=\"show\">div 1</div>"
+        }
+      ]
+    };
+
+    let result = parser.parse(xmlData, {
+      attributeNamePrefix: "",
+      ignoreAttributes:    false,
+      parseAttributeValue: true,
+      resembleXml: true,
+      stopNodes: ["fix1"]
+    });
+
+    //console.log(JSON.stringify(result,null,4));
+    expect(result).toEqual(expected);
+
+    result = validator.validate(xmlData);
+    expect(result).toBe(true);
+  });
+
+  it("3. parse from xml to json and back to xml", function() {
+    const xmlData = `<issue i1="i1v"><title t1="t1v">test 1</title></issue>`;
+    const expected = {
+      "nodeName": "issue",
+      "attr": {
+        "i1": "i1v"
+      },
+      "children": [
+        {
+          "nodeName": "title",
+          "attr": {
+            "t1": "t1v"
+          },
+          "val": "test 1"
+        }
+      ]
+    };
+
+    let result = parser.parse(xmlData, {
+      attributeNamePrefix: "",
+      ignoreAttributes:    false,
+      attrNodeName: "attr",
+      parseAttributeValue: true,
+      resembleXml: true
+    });
+    var defaultOptions = {
+      resembleXml: true
+    }
+    var j2xParser = new parser.j2xParser(defaultOptions)
+    var xml = j2xParser.parse(result);
+    //console.log(xml);
+    expect(xml).toEqual(xmlData);
+  });
+});

--- a/src/json2xml.js
+++ b/src/json2xml.js
@@ -18,6 +18,7 @@ const defaultOptions = {
   attrValueProcessor: function(a) {
     return a;
   },
+  resembleXml: false
 };
 
 const props = [
@@ -89,7 +90,7 @@ Parser.prototype.parse = function(jObj) {
 
 Parser.prototype.j2xBasic = function(jObj) {
   let tag = jObj.nodeName;
-  if ("nameSpace" in jObj) { tag = jObj.nameSpace + ":" + tag}
+  if ("namespace" in jObj) { tag = jObj.namespace + ":" + tag}
   tag = this.options.tagValueProcessor(tag)
   let val = '<' + tag
   if ((jObj.attr != null) && (Object.keys(jObj.attr).length > 0)) {

--- a/src/node2json.js
+++ b/src/node2json.js
@@ -2,9 +2,40 @@
 
 const util = require('./util');
 
+const copyObj = function (source, options) {
+  let target = {}
+    target.nodeName = source.tagname
+  let p = source.tagname.split(":")
+  if (p.length > 1) {
+    target.nodeName = p[1];
+    target.namespace = p[0];
+  }
+  if ((options.attrNodeName != false) && (source.attrsMap != null) && ("attr" in source.attrsMap)) {
+    let attrKeys = Object.keys(source.attrsMap.attr)
+    if (attrKeys.length > 0) {
+      target.attr = {}
+      attrKeys.forEach(key => {
+        target.attr[key] = source.attrsMap.attr[key]
+      })
+    }
+  }
+  if (source.val != "") {
+    target.val = source.val
+  }
+  if  (source.child.length > 0) {
+    target.children = []
+  }
+  source.child.forEach(c => {
+    target.children.push(copyObj(c, options))
+  })
+  return target
+}
 const convertToJson = function(node, options) {
-  const jObj = {};
-
+  var jObj = {};
+  if (options.resembleXml) {
+    jObj = copyObj(node.child[0], options)
+    return jObj
+  }
   //when no child node or attr is present
   if ((!node.child || util.isEmptyObject(node.child)) && (!node.attrsMap || util.isEmptyObject(node.attrsMap))) {
     return util.isExist(node.val) ? node.val : '';
@@ -20,9 +51,16 @@ const convertToJson = function(node, options) {
   util.merge(jObj, node.attrsMap);
 
   const keys = Object.keys(node.child);
+  if ("nodeNameAsType" in options) {
+    if (keys.length > 0) {
+      jObj[options.nodeNameAsType[1]] = []
+    }
+  }
+
   for (let index = 0; index < keys.length; index++) {
     var tagname = keys[index];
     if (node.child[tagname] && node.child[tagname].length > 1) {
+      //if ()
       jObj[tagname] = [];
       for (var tag in node.child[tagname]) {
         jObj[tagname].push(convertToJson(node.child[tagname][tag], options));

--- a/src/node2json.js
+++ b/src/node2json.js
@@ -19,7 +19,7 @@ const copyObj = function (source, options) {
       })
     }
   }
-  if (source.val != "") {
+  if (source.val !== "") {
     target.val = source.val
   }
   if  (source.child.length > 0) {

--- a/src/xmlNodeBasic.js
+++ b/src/xmlNodeBasic.js
@@ -1,0 +1,12 @@
+'use strict';
+
+module.exports = function(tagname, parent, val) {
+  this.tagname = tagname;
+  this.parent = parent;
+  this.child = []; //child tags
+  this.attrsMap = {}; //attributes map
+  this.val = val; //text only
+  this.addChild = function(child) {
+    this.child.push(child)
+  };
+};


### PR DESCRIPTION


# Purpose / Goal
Be able to parse each xml node in the form of { nodeName, attr, val, namespace, children}.
This makes it easier to process JSON from xml because there is not need to constantly check if a child node is an array or non-array.

This feature only applies when you enable resembleXml option (default is false). 

