### PR TITLE
fix validation for tag on multiple lines

### DIFF
--- a/spec/validator_spec.js
+++ b/spec/validator_spec.js
@@ -399,4 +399,16 @@ describe("XMLParser", function() {
         var result = validator.validate(xmlData).err;
         expect(result).toEqual(expected);
     });
+
+    it('should validate xml with a tag attribute splitted on more lines', () => {
+        const xmlData = `
+    <name
+    attribute1="attribute1"
+    attribute2="attribute2"
+    />
+            `;
+    
+        var result = validator.validate(xmlData);
+        expect(result).toEqual(true);
+      });
 });

--- a/src/validator.js
+++ b/src/validator.js
@@ -48,7 +48,16 @@ exports.validate = function(xmlData, options) {
         }
         //read tagname
         let tagName = '';
-        for (; i < xmlData.length && xmlData[i] !== '>' && xmlData[i] !== ' ' && xmlData[i] !== '\t'; i++) {
+        for (
+          ;
+          i < xmlData.length &&
+          xmlData[i] !== '>' &&
+          xmlData[i] !== ' ' &&
+          xmlData[i] !== '\t' &&
+          xmlData[i] !== '\n' &&
+          xmlData[i] !== '\r';
+          i++
+        ) {
           tagName += xmlData[i];
         }
         tagName = tagName.trim();


### PR DESCRIPTION
When a tag is split into multiple lines, validation fails.
For example
```
<name
attribute1="attribute1"
attribute2="attribute2"
/>
```
is considered invalid.

To solve this issue, I add a check also for new line characters.