### PR TITLE
bugfix(types): add stopNodes to X2jOptions

### DIFF
--- a/src/parser.d.ts
+++ b/src/parser.d.ts
@@ -15,6 +15,7 @@ type X2jOptions = {
   parseTrueNumberOnly: boolean;
   tagValueProcessor: (tagValue: string, tagName: string) => string;
   attrValueProcessor: (attrValue: string, attrName: string) => string;
+  stopNodes: string[];
 };
 type X2jOptionsOptional = Partial<X2jOptions>;
 type validationOptions = {


### PR DESCRIPTION
# Purpose / Goal
- Adds the `stopNodes` attribute to the `X2jOptions` in `src/parser.d.ts` so they can be used in typescript projects without the typescript compiler complaining (and ide's can autocomplete them).

Fixes #191

# Type
* [x] Bug Fix
* [ ] Refactoring / Technology upgrade
* [ ] New Feature