### PR TITLE
Added type support for arrayMode = 'strict'

### DIFF
--- a/src/parser.d.ts
+++ b/src/parser.d.ts
@@ -7,7 +7,7 @@ type X2jOptions = {
   allowBooleanAttributes: boolean;
   parseNodeValue: boolean;
   parseAttributeValue: boolean;
-  arrayMode: boolean;
+  arrayMode: boolean | 'strict';
   trimValues: boolean;
   cdataTagName: false | string;
   cdataPositionChar: string;


### PR DESCRIPTION
# Purpose / Goal
I noticed that while `arrayMode` supports `strict` as an option, the TS typings did not reflect that.

# Type
Please mention the type of PR
<!-- choose one by changing [ ] to [x] -->
* [x]Bug Fix
* [ ]Refactoring / Technology upgrade
* [ ]New Feature
