### PR TITLE
Fix validation of self-closing tag followed by text

### DIFF
--- a/spec/validator_spec.js
+++ b/spec/validator_spec.js
@@ -50,19 +50,41 @@ describe("XMLParser", function() {
     });
 
     it("should validate self closing tags", function() {
-        const xmlData = "<rootNode><validtag1  /><validtag2/><validtag3  with='attrib'/></rootNode>";
+        const xmlData = "<rootNode><validtag1  /><validtag2/><validtag3  with='attrib'/><validtag4 />text<validtag5/>text</rootNode>";
         const result = validator.validate(xmlData);
         expect(result).toBe(true);
     });
 
-    it("should not validate self closing tags", function() {
-        const xmlData = "<rootNode><validtag1/><invalid tag/><validtag3  with='attrib'/></rootNode>";
-        const expected = {code: "InvalidAttr", msg: "boolean attribute tag is not allowed."};
+    it("should not consider these as self closing tags", function() {
+        let xmlData = "<rootNode><validtag1/><invalid tag/><validtag3  with='attrib'/></rootNode>";
+        let expected = {code: "InvalidAttr", msg: "boolean attribute tag is not allowed."};
 
-        const result = validator.validate(xmlData).err;
+        let result = validator.validate(xmlData).err;
         //console.log(JSON.stringify(result,null,4));
         expect(result).toEqual(expected);
+
+        xmlData = "<rootNode><notSelfClosing/ ></rootNode>";
+        expected = {code: "InvalidAttr", msg: "attribute / has no space in starting."};
+
+        result = validator.validate(xmlData).err;
+        expect(result).toEqual(expected);
     });
+
+    /*
+    it("should correctly identify self closing tags", function() {
+        let xmlData = "<rootNode><in/valid></in/valid></rootNode>";
+        let expected = {code: "InvalidTag", msg: "Tag in/valid is an invalid name."};
+
+        let result = validator.validate(xmlData).err;
+        expect(result).toEqual(expected);
+
+        xmlData = "<rootNode><in#valid/></rootNode>";
+        expected = {code: "InvalidTag", msg: "Tag in#valid is an invalid name."};
+
+        result = validator.validate(xmlData).err;
+        expect(result).toEqual(expected);
+    });
+    */
 
     it("should not validate xml string when closing tag is different", function() {
         const xmlData = "<rootNode></rootnode>";

--- a/src/validator.js
+++ b/src/validator.js
@@ -66,7 +66,7 @@ exports.validate = function(xmlData, options) {
         if (tagName[tagName.length - 1] === '/') {
           //self closing tag without attributes
           tagName = tagName.substring(0, tagName.length - 1);
-          continue;
+          i--;
         }
         if (!validateTagName(tagName, regxTagName)) {
           return {err: {code: 'InvalidTag', msg: 'Tag ' + tagName + ' is an invalid name.'}};


### PR DESCRIPTION
If there is no space before the closing tag, and the tag is followed by text, validation failed:

```
<main><empty/>text</main>
```

# Purpose / Goal
<!-- Please specify here what you're planning to achieve by this pull request and how it can help in regard of this work-space. -->

<!-- If it is a bug fix, please mention the issue number. If there is no issue has been raised but the PR directly then it should follow the template given to raise the issue. Like input, expected output, actual output etc. -->


# Type
Please mention the type of PR
<!-- choose one by changing [ ] to [x] -->
* [X]Bug Fix
* [ ]Refactoring / Technology upgrade
* [ ]New Feature
