### PR TITLE
Validator: Fix name regexp

### DIFF
--- a/spec/validator_utf8_with_BOM_spec.js
+++ b/spec/validator_utf8_with_BOM_spec.js
@@ -3,12 +3,10 @@
 const validator = require("../src/validator");
 
 describe("XMLParser", function() {
-
     it("should validate xml string with cyrillic characters", function() {
         const BOM = "\ufeff";
-        const options = {localeRange: "a-zA-Zа-яёА-ЯЁ"}
         let xmlData = BOM + "<?xml version=\"1.0\" encoding=\"utf-8\" ?><КорневаяЗапись><Тэг>ЗначениеValue53456</Тэг></КорневаяЗапись>";
-        let result = validator.validate(xmlData, options);
+        let result = validator.validate(xmlData);
         expect(result).toBe(true);
 
     });

--- a/spec/x_cyrillic_2j_str_spec.js
+++ b/spec/x_cyrillic_2j_str_spec.js
@@ -1,7 +1,6 @@
 "use strict";
 
 const parser = require("../src/parser");
-const validator = require("../src/validator");
 
 describe("XMLParser", function() {
 
@@ -13,29 +12,12 @@ describe("XMLParser", function() {
             }
         };
         const options = {
-          localeRange: "а-яёА-ЯЁa-zA-Z",
           attributeNamePrefix : "@_"
         }
 
-        const result = parser.parse(xmlData, options, { localeRange: "а-яёА-ЯЁa-zA-Z" });
+        const result = parser.parse(xmlData, options);
         expect(result).toEqual(expected);
         // console.log({ expected})
         // console.log({ result })
     });
-
-    it("should invalid XML with invalid localRange", function() {
-        const xmlData = `<КорневаяЗапись><Тэг>ЗначениеValue53456</Тэг></КорневаяЗапись>`;
-
-        const expected = {
-            "code": "InvalidOptions",
-            "msg":  "Invalid localeRange",
-            "line": 1
-        };
-
-        const result = validator.validate(xmlData , { localeRange: "а-яёА-ЯЁa-zA-Z<" }).err
-        expect(result).toEqual(expected);
-        // console.log({ expected})
-        // console.log({ result })
-    });
-
 });

--- a/src/parser.d.ts
+++ b/src/parser.d.ts
@@ -11,7 +11,6 @@ type X2jOptions = {
   trimValues: boolean;
   cdataTagName: false | string;
   cdataPositionChar: string;
-  localeRange:  string;
   parseTrueNumberOnly: boolean;
   tagValueProcessor: (tagValue: string, tagName: string) => string;
   attrValueProcessor: (attrValue: string, attrName: string) => string;
@@ -20,7 +19,6 @@ type X2jOptions = {
 type X2jOptionsOptional = Partial<X2jOptions>;
 type validationOptions = {
   allowBooleanAttributes: boolean;
-  localeRange: string;
 };
 type validationOptionsOptional = Partial<validationOptions>;
 type J2xOptions = {

--- a/src/util.js
+++ b/src/util.js
@@ -1,5 +1,10 @@
 'use strict';
 
+const nameStartChar = ':A-Za-z_\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u02FF\\u0370-\\u037D\\u037F-\\u1FFF\\u200C-\\u200D\\u2070-\\u218F\\u2C00-\\u2FEF\\u3001-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFFD';
+const nameChar = nameStartChar + '\\-.\\d\\u00B7\\u0300-\\u036F\\u203F-\\u2040';
+const nameRegexp = '[' + nameStartChar + '][' + nameChar + ']*'
+const regexName = new RegExp('^' + nameRegexp + '$');
+
 const getAllMatches = function(string, regex) {
   const matches = [];
   let match = regex.exec(string);
@@ -15,13 +20,9 @@ const getAllMatches = function(string, regex) {
   return matches;
 };
 
-const doesMatch = function(string, regex) {
-  const match = regex.exec(string);
+const isName = function(string) {
+  const match = regexName.exec(string);
   return !(match === null || typeof match === 'undefined');
-};
-
-const doesNotMatch = function(string, regex) {
-  return !doesMatch(string, regex);
 };
 
 exports.isExist = function(v) {
@@ -81,6 +82,6 @@ exports.buildOptions = function(options, defaultOptions, props) {
   return newOptions;
 };
 
-exports.doesMatch = doesMatch;
-exports.doesNotMatch = doesNotMatch;
+exports.isName = isName;
 exports.getAllMatches = getAllMatches;
+exports.nameRegexp = nameRegexp;


### PR DESCRIPTION
# Purpose / Goal
Validator: Fix name regexp

The previous implementation only allowed the "localeRange" for the first character, and it did not validate the following characters at all, because the regexp did not include $, so if the first character
matched, the regexp would match.

Replace the regexp with one that matches the [XML spec](https://www.w3.org/TR/xml/#NT-NameStartChar) (except [\u10000-\uEFFFF] which matches digits for some reason...) and match *all* the characters.

Remove the localeRange option, which is no longer needed

# Type
Please mention the type of PR
<!-- choose one by changing [ ] to [x] -->
* [X]Bug Fix
* [ ]Refactoring / Technology upgrade
* [ ]New Feature
