### PR TITLE
Added a way to preserve order, #197.

### DIFF
--- a/spec/xmlParser_spec.js
+++ b/spec/xmlParser_spec.js
@@ -6,7 +6,7 @@ const validator = require("../src/validator");
 describe("XMLParser", function () {
 
     it("should preserve the position of tags when specified", function () {
-        const xmlData = `<store> locates in
+        const xmlData = `<store attr="value"> locates in
                 <region>US</region>
                 and
                 <region>Japan</region>
@@ -15,7 +15,8 @@ describe("XMLParser", function () {
 
         const expected = {
             "store": [{
-                "": [
+                "@_attr": "value",
+                "#ordered": [
                     { "#text": "locates in" },
                     { "region": "US" },
                     { "#text": "and" },
@@ -25,7 +26,7 @@ describe("XMLParser", function () {
             }]
         }
 
-        const result = parser.parse(xmlData, { arrayMode: true, preserveOrder: true });
+        const result = parser.parse(xmlData, { arrayMode: true, preserveOrder: true, ignoreAttributes: false });
         //console.log(JSON.stringify(result, null, 4));
         expect(result).toEqual(expected);
     })
@@ -49,7 +50,7 @@ describe("XMLParser", function () {
         const expected = {
             root: [{
                 store: [{
-                    "": [
+                    "#ordered": [
                         { "#text": "locates in" },
                         { "region": "US" },
                         { "#text": "and" },
@@ -65,7 +66,7 @@ describe("XMLParser", function () {
         }
 
         const result = parser.parse(xmlData, { arrayMode: true, preserveOrder: "text" });
-//        console.log(JSON.stringify(result, null, 4));
+        //        console.log(JSON.stringify(result, null, 4));
         expect(result).toEqual(expected);
     })
 
@@ -87,10 +88,10 @@ describe("XMLParser", function () {
 
         const expected = {
             root: [{
-                "": [
+                "#ordered": [
                     {
                         store: {
-                            "": [
+                            "#ordered": [
                                 { "#text": "locates in" },
                                 { "region": "US" },
                                 { "#text": "and" },
@@ -101,7 +102,7 @@ describe("XMLParser", function () {
                     },
                     {
                         second: {
-                            "": [{ a: 1 }, { b: 2 }, { a: 3 }]
+                            "#ordered": [{ a: 1 }, { b: 2 }, { a: 3 }]
                         }
                     }
                 ]
@@ -113,151 +114,151 @@ describe("XMLParser", function () {
         expect(result).toEqual(expected);
     })
 
-        it("should ignore the position of tags by default", function () {
-            const xmlData = `<store> locates in
+    it("should ignore the position of tags by default", function () {
+        const xmlData = `<store> locates in
                     <region>US</region>
                     and
                     <region>Japan</region>
                     only
             </store>`
 
-            const expected = {
-                "store": [
-                    {
-                        "#text": "locates inandonly",
-                        "region": [
-                            "US",
-                            "Japan"
-                        ]
-                    }
-                ]
-            }
+        const expected = {
+            "store": [
+                {
+                    "#text": "locates inandonly",
+                    "region": [
+                        "US",
+                        "Japan"
+                    ]
+                }
+            ]
+        }
 
-            const result = parser.parse(xmlData, { arrayMode: true });
-            //console.log(JSON.stringify(result, null, 4));
-            expect(result).toEqual(expected);
-        })
+        const result = parser.parse(xmlData, { arrayMode: true });
+        //console.log(JSON.stringify(result, null, 4));
+        expect(result).toEqual(expected);
+    })
 
-        it("should parse all values as string, int, boolean, float, hexadecimal", function () {
-            const xmlData = `<rootNode>
+    it("should parse all values as string, int, boolean, float, hexadecimal", function () {
+        const xmlData = `<rootNode>
             <tag>value</tag>
             <boolean>true</boolean>
             <intTag>045</intTag>
             <floatTag>65.340</floatTag>
             <hexadecimal>0x15</hexadecimal>
             </rootNode>`;
-            const expected = {
-                "rootNode": {
-                    "tag": "value",
-                    "boolean": true,
-                    "intTag": 45,
-                    "floatTag": 65.34,
-                    "hexadecimal": 21
-                }
-            };
+        const expected = {
+            "rootNode": {
+                "tag": "value",
+                "boolean": true,
+                "intTag": 45,
+                "floatTag": 65.34,
+                "hexadecimal": 21
+            }
+        };
 
-            const result = parser.parse(xmlData);
-            //console.log(JSON.stringify(result,null,4));
-            expect(result).toEqual(expected);
-        });
+        const result = parser.parse(xmlData);
+        //console.log(JSON.stringify(result,null,4));
+        expect(result).toEqual(expected);
+    });
 
 
-        it("should parse only true numbers", function () {
-            const xmlData = `<rootNode>
+    it("should parse only true numbers", function () {
+        const xmlData = `<rootNode>
             <tag>value</tag>
             <boolean>true</boolean>
             <intTag>045</intTag>
             <floatTag>65.34</floatTag>
             <long>420926189200190257681175017717</long>
             </rootNode>`;
-            const expected = {
-                "rootNode": {
-                    "tag": "value",
-                    "boolean": true,
-                    "intTag": "045",
-                    "floatTag": 65.34,
-                    "long": "420926189200190257681175017717"
-                }
-            };
+        const expected = {
+            "rootNode": {
+                "tag": "value",
+                "boolean": true,
+                "intTag": "045",
+                "floatTag": 65.34,
+                "long": "420926189200190257681175017717"
+            }
+        };
 
-            const result = parser.parse(xmlData, {
-                parseTrueNumberOnly: true
-            });
-            //console.log(JSON.stringify(result,null,4));
-            expect(result).toEqual(expected);
+        const result = parser.parse(xmlData, {
+            parseTrueNumberOnly: true
+        });
+        //console.log(JSON.stringify(result,null,4));
+        expect(result).toEqual(expected);
+    });
+
+    it("should not parse values to primitive type", function () {
+        const xmlData = `<rootNode><tag>value</tag><boolean>true</boolean><intTag>045</intTag><floatTag>65.34</floatTag></rootNode>`;
+        const expected = {
+            "rootNode": {
+                "tag": "value",
+                "boolean": "true",
+                "intTag": "045",
+                "floatTag": "65.34"
+            }
+        };
+
+        const result = parser.parse(xmlData, {
+            parseNodeValue: false
+        });
+        expect(result).toEqual(expected);
+    });
+
+    it("should parse number values of attributes as number", function () {
+        const xmlData = `<rootNode><tag int='045' intNegative='-045' float='65.34' floatNegative='-65.34'>value</tag></rootNode>`;
+        const expected = {
+            "rootNode": {
+                "tag": {
+                    "#text": "value",
+                    "@_int": 45,
+                    "@_intNegative": -45,
+                    "@_float": 65.34,
+                    "@_floatNegative": -65.34
+                }
+            }
+        };
+
+        const result = parser.parse(xmlData, {
+            ignoreAttributes: false,
+            parseAttributeValue: true
         });
 
-        it("should not parse values to primitive type", function () {
-            const xmlData = `<rootNode><tag>value</tag><boolean>true</boolean><intTag>045</intTag><floatTag>65.34</floatTag></rootNode>`;
-            const expected = {
-                "rootNode": {
-                    "tag": "value",
-                    "boolean": "true",
-                    "intTag": "045",
-                    "floatTag": "65.34"
-                }
-            };
+        expect(result).toEqual(expected);
+    });
 
-            const result = parser.parse(xmlData, {
-                parseNodeValue: false
-            });
-            expect(result).toEqual(expected);
+    it("should parse number values as number if flag is set", function () {
+        const xmlData = `<rootNode><tag>value</tag><intTag>045</intTag><intTag>0</intTag><floatTag>65.34</floatTag></rootNode>`;
+        const expected = {
+            "rootNode": {
+                "tag": "value",
+                "intTag": [45, 0],
+                "floatTag": 65.34
+            }
+        };
+
+        const result = parser.parse(xmlData, {
+            parseNodeValue: true
         });
+        expect(result).toEqual(expected);
+    });
 
-        it("should parse number values of attributes as number", function () {
-            const xmlData = `<rootNode><tag int='045' intNegative='-045' float='65.34' floatNegative='-65.34'>value</tag></rootNode>`;
-            const expected = {
-                "rootNode": {
-                    "tag": {
-                        "#text": "value",
-                        "@_int": 45,
-                        "@_intNegative": -45,
-                        "@_float": 65.34,
-                        "@_floatNegative": -65.34
-                    }
-                }
-            };
+    it("should skip tag arguments", function () {
+        const xmlData = `<rootNode><tag ns:arg='value'>value</tag><intTag ns:arg='value' ns:arg2='value2' >45</intTag><floatTag>65.34</floatTag></rootNode>`;
+        const expected = {
+            "rootNode": {
+                "tag": "value",
+                "intTag": 45,
+                "floatTag": 65.34
+            }
+        };
 
-            const result = parser.parse(xmlData, {
-                ignoreAttributes: false,
-                parseAttributeValue: true
-            });
+        const result = parser.parse(xmlData);
+        expect(result).toEqual(expected);
+    });
 
-            expect(result).toEqual(expected);
-        });
-
-        it("should parse number values as number if flag is set", function () {
-            const xmlData = `<rootNode><tag>value</tag><intTag>045</intTag><intTag>0</intTag><floatTag>65.34</floatTag></rootNode>`;
-            const expected = {
-                "rootNode": {
-                    "tag": "value",
-                    "intTag": [45, 0],
-                    "floatTag": 65.34
-                }
-            };
-
-            const result = parser.parse(xmlData, {
-                parseNodeValue: true
-            });
-            expect(result).toEqual(expected);
-        });
-
-        it("should skip tag arguments", function () {
-            const xmlData = `<rootNode><tag ns:arg='value'>value</tag><intTag ns:arg='value' ns:arg2='value2' >45</intTag><floatTag>65.34</floatTag></rootNode>`;
-            const expected = {
-                "rootNode": {
-                    "tag": "value",
-                    "intTag": 45,
-                    "floatTag": 65.34
-                }
-            };
-
-            const result = parser.parse(xmlData);
-            expect(result).toEqual(expected);
-        });
-
-        it("should ignore namespace and text node attributes", function () {
-            const xmlData = `\
+    it("should ignore namespace and text node attributes", function () {
+        const xmlData = `\
     <root:node>
         <tag ns:arg='value'>value</tag>
         <intTag ns:arg='value' ns:arg2='value2' >45</intTag>
@@ -266,96 +267,96 @@ describe("XMLParser", function () {
         <nsTagNoAttr xmlns:tns-ns='urn:none'></nsTagNoAttr>
     </root:node>`;
 
-            const expected = {
-                "node": {
-                    "tag": {
-                        "@_arg": "value",
-                        "#text": "value"
-                    },
-                    "intTag": {
-                        "@_arg": "value",
-                        "@_arg2": "value2",
-                        "#text": 45
-                    },
-                    "floatTag": 65.34,
-                    "nsTag": {
-                        "@_attr": "tns"
-                        //"#text": ""
-                    },
-                    "nsTagNoAttr": ""
-                }
-            };
-
-            const result = parser.parse(xmlData, {
-                ignoreNameSpace: true,
-                ignoreAttributes: false
-            });
-
-            expect(result).toEqual(expected);
-        });
-
-        it("should parse empty text Node", function () {
-            const xmlData = `<rootNode><tag></tag></rootNode>`;
-            const expected = {
-                "rootNode": {
-                    "tag": ""
-                }
-            };
-
-            const result = parser.parse(xmlData);
-            expect(result).toEqual(expected);
-        });
-
-        it("should parse self closing tags", function () {
-            const xmlData = "<rootNode><tag ns:arg='value'/></rootNode>";
-            const expected = {
-                "rootNode": {
-                    "tag": {
-                        "@_ns:arg": "value"
-                    }
-                }
-            };
-
-            const result = parser.parse(xmlData, {
-                ignoreAttributes: false
-            });
-            expect(result).toEqual(expected);
-        });
-
-        it("should parse single self closing tag", function () {
-            const xmlData = `<tag arg='value'/>`;
-            const expected = {
+        const expected = {
+            "node": {
                 "tag": {
-                    "@_arg": "value"
-                }
-            };
+                    "@_arg": "value",
+                    "#text": "value"
+                },
+                "intTag": {
+                    "@_arg": "value",
+                    "@_arg2": "value2",
+                    "#text": 45
+                },
+                "floatTag": 65.34,
+                "nsTag": {
+                    "@_attr": "tns"
+                    //"#text": ""
+                },
+                "nsTagNoAttr": ""
+            }
+        };
 
-            //console.log(parser.getTraversalObj(xmlData));
-            const result = parser.parse(xmlData, {
-                ignoreAttributes: false
-            });
-            expect(result).toEqual(expected);
+        const result = parser.parse(xmlData, {
+            ignoreNameSpace: true,
+            ignoreAttributes: false
         });
 
-        it("should parse repeated nodes in array", function () {
-            const xmlData = `\
+        expect(result).toEqual(expected);
+    });
+
+    it("should parse empty text Node", function () {
+        const xmlData = `<rootNode><tag></tag></rootNode>`;
+        const expected = {
+            "rootNode": {
+                "tag": ""
+            }
+        };
+
+        const result = parser.parse(xmlData);
+        expect(result).toEqual(expected);
+    });
+
+    it("should parse self closing tags", function () {
+        const xmlData = "<rootNode><tag ns:arg='value'/></rootNode>";
+        const expected = {
+            "rootNode": {
+                "tag": {
+                    "@_ns:arg": "value"
+                }
+            }
+        };
+
+        const result = parser.parse(xmlData, {
+            ignoreAttributes: false
+        });
+        expect(result).toEqual(expected);
+    });
+
+    it("should parse single self closing tag", function () {
+        const xmlData = `<tag arg='value'/>`;
+        const expected = {
+            "tag": {
+                "@_arg": "value"
+            }
+        };
+
+        //console.log(parser.getTraversalObj(xmlData));
+        const result = parser.parse(xmlData, {
+            ignoreAttributes: false
+        });
+        expect(result).toEqual(expected);
+    });
+
+    it("should parse repeated nodes in array", function () {
+        const xmlData = `\
     <rootNode>
         <tag>value</tag>
         <tag>45</tag>
         <tag>65.34</tag>
     </rootNode>`;
-            const expected = {
-                "rootNode": {
-                    "tag": ["value", 45, 65.34]
-                }
-            };
+        const expected = {
+            "rootNode": {
+                "tag": ["value", 45, 65.34]
+            }
+        };
 
-            const result = parser.parse(xmlData);
-            expect(result).toEqual(expected);
-        });
+        const result = parser.parse(xmlData);
+        expect(result).toEqual(expected);
+    });
 
-        it("should parse nested nodes in nested properties", function () {
-            const xmlData = `\
+    it("should parse nested nodes in nested properties", function () {
+        const xmlData = `\
     <rootNode>
         <parenttag>
             <tag>value</tag>
@@ -363,20 +364,20 @@ describe("XMLParser", function () {
             <tag>65.34</tag>
         </parenttag>
     </rootNode>`;
-            const expected = {
-                "rootNode": {
-                    "parenttag": {
-                        "tag": ["value", 45, 65.34]
-                    }
+        const expected = {
+            "rootNode": {
+                "parenttag": {
+                    "tag": ["value", 45, 65.34]
                 }
-            };
+            }
+        };
 
-            const result = parser.parse(xmlData);
-            expect(result).toEqual(expected);
-        });
+        const result = parser.parse(xmlData);
+        expect(result).toEqual(expected);
+    });
 
-        it("should parse non-text nodes with value for repeated nodes", function () {
-            const xmlData = `
+    it("should parse non-text nodes with value for repeated nodes", function () {
+        const xmlData = `
     <rootNode>
         <parenttag attr1='some val' attr2='another val'>
             <tag>value</tag>
@@ -389,111 +390,111 @@ describe("XMLParser", function () {
             <tag>65.34</tag>
         </parenttag>
     </rootNode>`;
-            const expected = {
-                "rootNode": {
-                    "parenttag": [
-                        {
-                            "@_attr1": "some val",
-                            "@_attr2": "another val",
-                            "tag": [
-                                "value",
-                                {
-                                    "@_attr1": "val",
-                                    "@_attr2": "234",
-                                    "#text": 45
-                                },
-                                65.34
-                            ]
-                        }, {
-                            "@_attr1": "some val",
-                            "@_attr2": "another val",
-                            "tag": [
-                                "value",
-                                {
-                                    "@_attr1": "val",
-                                    "@_attr2": "234",
-                                    "#text": 45
-                                },
-                                65.34
-                            ]
-                        }
-                    ]
-                }
-            };
-
-            const result = parser.parse(xmlData, {
-                ignoreAttributes: false
-            });
-            expect(result).toEqual(expected);
-        });
-
-        it("should preserve node value", function () {
-            const xmlData = `<rootNode attr1=' some val ' name='another val'> some val </rootNode>`;
-            const expected = {
-                "rootNode": {
-                    "@_attr1": " some val ",
-                    "@_name": "another val",
-                    "#text": " some val "
-                }
-            };
-
-            const result = parser.parse(xmlData, {
-                ignoreAttributes: false,
-                trimValues: false
-            });
-            expect(result).toEqual(expected);
-        });
-
-        it("should parse with attributes and value when there is single node", function () {
-            const xmlData = `<rootNode attr1='some val' attr2='another val'>val</rootNode>`;
-            const expected = {
-                "rootNode": {
-                    "@_attr1": "some val",
-                    "@_attr2": "another val",
-                    "#text": "val"
-                }
-            };
-
-            const result = parser.parse(xmlData, {
-                ignoreAttributes: false
-            });
-            expect(result).toEqual(expected);
-        });
-
-        it("should parse different tags", function () {
-            const xmlData = `<tag.1>val1</tag.1><tag.2>val2</tag.2>`;
-            const expected = {
-                "tag.1": "val1",
-                "tag.2": "val2"
-            };
-
-            const result = parser.parse(xmlData, {
-                ignoreAttributes: false
-            });
-            expect(result).toEqual(expected);
-        });
-
-        it("should not parse text value with tag", function () {
-            const xmlData = `<score><c1>71<message>23</message>29</c1></score>`;
-            const expected = {
-                "score": {
-                    "c1": {
-                        "message": 23,
-                        "_text": "7129"
+        const expected = {
+            "rootNode": {
+                "parenttag": [
+                    {
+                        "@_attr1": "some val",
+                        "@_attr2": "another val",
+                        "tag": [
+                            "value",
+                            {
+                                "@_attr1": "val",
+                                "@_attr2": "234",
+                                "#text": 45
+                            },
+                            65.34
+                        ]
+                    }, {
+                        "@_attr1": "some val",
+                        "@_attr2": "another val",
+                        "tag": [
+                            "value",
+                            {
+                                "@_attr1": "val",
+                                "@_attr2": "234",
+                                "#text": 45
+                            },
+                            65.34
+                        ]
                     }
+                ]
+            }
+        };
+
+        const result = parser.parse(xmlData, {
+            ignoreAttributes: false
+        });
+        expect(result).toEqual(expected);
+    });
+
+    it("should preserve node value", function () {
+        const xmlData = `<rootNode attr1=' some val ' name='another val'> some val </rootNode>`;
+        const expected = {
+            "rootNode": {
+                "@_attr1": " some val ",
+                "@_name": "another val",
+                "#text": " some val "
+            }
+        };
+
+        const result = parser.parse(xmlData, {
+            ignoreAttributes: false,
+            trimValues: false
+        });
+        expect(result).toEqual(expected);
+    });
+
+    it("should parse with attributes and value when there is single node", function () {
+        const xmlData = `<rootNode attr1='some val' attr2='another val'>val</rootNode>`;
+        const expected = {
+            "rootNode": {
+                "@_attr1": "some val",
+                "@_attr2": "another val",
+                "#text": "val"
+            }
+        };
+
+        const result = parser.parse(xmlData, {
+            ignoreAttributes: false
+        });
+        expect(result).toEqual(expected);
+    });
+
+    it("should parse different tags", function () {
+        const xmlData = `<tag.1>val1</tag.1><tag.2>val2</tag.2>`;
+        const expected = {
+            "tag.1": "val1",
+            "tag.2": "val2"
+        };
+
+        const result = parser.parse(xmlData, {
+            ignoreAttributes: false
+        });
+        expect(result).toEqual(expected);
+    });
+
+    it("should not parse text value with tag", function () {
+        const xmlData = `<score><c1>71<message>23</message>29</c1></score>`;
+        const expected = {
+            "score": {
+                "c1": {
+                    "message": 23,
+                    "_text": "7129"
                 }
-            };
+            }
+        };
 
-            const result = parser.parse(xmlData, {
-                textNodeName: "_text",
-                ignoreAttributes: false
-            });
-
-            expect(result).toEqual(expected);
+        const result = parser.parse(xmlData, {
+            textNodeName: "_text",
+            ignoreAttributes: false
         });
 
-        it("should parse nested elements with attributes", function () {
-            const xmlData = `\
+        expect(result).toEqual(expected);
+    });
+
+    it("should parse nested elements with attributes", function () {
+        const xmlData = `\
     <root>
         <Meet date="2017-05-03" type="A" name="Meeting 'A'">
             <Event time="00:05:00" ID="574" Name="Some Event Name">
@@ -501,35 +502,35 @@ describe("XMLParser", function () {
             </Event>
         </Meet>
     </root>`;
-            const expected = {
-                "root": {
-                    "Meet": {
-                        "@_date": "2017-05-03",
-                        "@_type": "A",
-                        "@_name": "Meeting 'A'",
-                        "Event": {
-                            "@_time": "00:05:00",
-                            "@_ID": "574",
-                            "@_Name": "Some Event Name",
-                            "User": {
-                                "@_ID": "1",
-                                "#text": "Bob"
-                            }
+        const expected = {
+            "root": {
+                "Meet": {
+                    "@_date": "2017-05-03",
+                    "@_type": "A",
+                    "@_name": "Meeting 'A'",
+                    "Event": {
+                        "@_time": "00:05:00",
+                        "@_ID": "574",
+                        "@_Name": "Some Event Name",
+                        "User": {
+                            "@_ID": "1",
+                            "#text": "Bob"
                         }
                     }
                 }
-            };
+            }
+        };
 
-            const result = parser.parse(xmlData, {
-                ignoreAttributes: false,
-                ignoreNonTextNodeAttr: false
-            });
-
-            expect(result).toEqual(expected);
+        const result = parser.parse(xmlData, {
+            ignoreAttributes: false,
+            ignoreNonTextNodeAttr: false
         });
 
-        it("should parse nested elements with attributes wrapped in object", function () {
-            const xmlData = `\
+        expect(result).toEqual(expected);
+    });
+
+    it("should parse nested elements with attributes wrapped in object", function () {
+        const xmlData = `\
     <root xmlns="urn:none" xmlns:tns-ns="urn:none">
         <Meet xmlns="urn:none" tns-ns:nsattr="attr" date="2017-05-03" type="A" name="Meeting 'A'">
             <Event time="00:05:00" ID="574" Name="Some Event Name">
@@ -537,199 +538,199 @@ describe("XMLParser", function () {
             </Event>
         </Meet>
     </root>`;
-            const expected = {
-                "root": {
-                    "Meet": {
+        const expected = {
+            "root": {
+                "Meet": {
+                    "$": {
+                        "nsattr": "attr",
+                        "date": "2017-05-03",
+                        "type": "A",
+                        "name": "Meeting 'A'"
+                    },
+                    "Event": {
                         "$": {
-                            "nsattr": "attr",
-                            "date": "2017-05-03",
-                            "type": "A",
-                            "name": "Meeting 'A'"
+                            "time": "00:05:00",
+                            "ID": "574",
+                            "Name": "Some Event Name"
                         },
-                        "Event": {
+                        "User": {
                             "$": {
-                                "time": "00:05:00",
-                                "ID": "574",
-                                "Name": "Some Event Name"
+                                "ID": "1"
                             },
-                            "User": {
-                                "$": {
-                                    "ID": "1"
-                                },
-                                "#text": "Bob"
-                            }
+                            "#text": "Bob"
                         }
                     }
                 }
-            };
+            }
+        };
 
-            const result = parser.parse(xmlData, {
-                attributeNamePrefix: "",
-                attrNodeName: "$",
-                ignoreNameSpace: true,
-                ignoreAttributes: false
-            });
-
-            //console.log(JSON.stringify(result,null,4));
-            expect(result).toEqual(expected);
+        const result = parser.parse(xmlData, {
+            attributeNamePrefix: "",
+            attrNodeName: "$",
+            ignoreNameSpace: true,
+            ignoreAttributes: false
         });
 
-        it("should parse all type of nodes", function () {
-            const fs = require("fs");
-            const path = require("path");
-            const fileNamePath = path.join(__dirname, "assets/sample.xml");
-            const xmlData = fs.readFileSync(fileNamePath).toString();
+        //console.log(JSON.stringify(result,null,4));
+        expect(result).toEqual(expected);
+    });
 
-            const expected = {
-                "any_name": {
-                    "@attr": "https://example.com/somepath",
-                    "person": [
-                        {
-                            "@id": "101",
-                            "phone": [122233344550, 122233344551],
-                            "name": "Jack",
-                            "age": 33,
-                            "emptyNode": "",
-                            "booleanNode": [false, true],
-                            "selfclosing": [
-                                "",
-                                {
-                                    "@with": "value"
-                                }
-                            ],
-                            "married": {
-                                "@firstTime": "No",
-                                "@attr": "val 2",
-                                "#_text": "Yes"
-                            },
-                            "birthday": "Wed, 28 Mar 1979 12:13:14 +0300",
-                            "address": [
-                                {
-                                    "city": "New York",
-                                    "street": "Park Ave",
-                                    "buildingNo": 1,
-                                    "flatNo": 1
-                                }, {
-                                    "city": "Boston",
-                                    "street": "Centre St",
-                                    "buildingNo": 33,
-                                    "flatNo": 24
-                                }
-                            ]
-                        }, {
-                            "@id": "102",
-                            "phone": [122233344553, 122233344554],
-                            "name": "Boris",
-                            "age": 34,
-                            "married": {
-                                "@firstTime": "Yes",
-                                "#_text": "Yes"
-                            },
-                            "birthday": "Mon, 31 Aug 1970 02:03:04 +0300",
-                            "address": [
-                                {
-                                    "city": "Moscow",
-                                    "street": "Kahovka",
-                                    "buildingNo": 1,
-                                    "flatNo": 2
-                                }, {
-                                    "city": "Tula",
-                                    "street": "Lenina",
-                                    "buildingNo": 3,
-                                    "flatNo": 78
-                                }
-                            ]
-                        }
-                    ]
-                }
-            };
+    it("should parse all type of nodes", function () {
+        const fs = require("fs");
+        const path = require("path");
+        const fileNamePath = path.join(__dirname, "assets/sample.xml");
+        const xmlData = fs.readFileSync(fileNamePath).toString();
 
-            const result = parser.parse(xmlData, {
-                ignoreAttributes: false,
-                ignoreNonTextNodeAttr: false,
-                attributeNamePrefix: "@",
-                textNodeName: "#_text"
-            });
-            //console.log(JSON.stringify(result,null,4));
-            expect(result).toEqual(expected);
-        });
+        const expected = {
+            "any_name": {
+                "@attr": "https://example.com/somepath",
+                "person": [
+                    {
+                        "@id": "101",
+                        "phone": [122233344550, 122233344551],
+                        "name": "Jack",
+                        "age": 33,
+                        "emptyNode": "",
+                        "booleanNode": [false, true],
+                        "selfclosing": [
+                            "",
+                            {
+                                "@with": "value"
+                            }
+                        ],
+                        "married": {
+                            "@firstTime": "No",
+                            "@attr": "val 2",
+                            "#_text": "Yes"
+                        },
+                        "birthday": "Wed, 28 Mar 1979 12:13:14 +0300",
+                        "address": [
+                            {
+                                "city": "New York",
+                                "street": "Park Ave",
+                                "buildingNo": 1,
+                                "flatNo": 1
+                            }, {
+                                "city": "Boston",
+                                "street": "Centre St",
+                                "buildingNo": 33,
+                                "flatNo": 24
+                            }
+                        ]
+                    }, {
+                        "@id": "102",
+                        "phone": [122233344553, 122233344554],
+                        "name": "Boris",
+                        "age": 34,
+                        "married": {
+                            "@firstTime": "Yes",
+                            "#_text": "Yes"
+                        },
+                        "birthday": "Mon, 31 Aug 1970 02:03:04 +0300",
+                        "address": [
+                            {
+                                "city": "Moscow",
+                                "street": "Kahovka",
+                                "buildingNo": 1,
+                                "flatNo": 2
+                            }, {
+                                "city": "Tula",
+                                "street": "Lenina",
+                                "buildingNo": 3,
+                                "flatNo": 78
+                            }
+                        ]
+                    }
+                ]
+            }
+        };
 
-        /* it("should parse nodes as arrays", function () {
-          const fs = require("fs");
-          const path = require("path");
-          const fileNamePath = path.join(__dirname, "assets/sample.xml");
-          const xmlData = fs.readFileSync(fileNamePath).toString();
-
-          const expected = {
-            "any_name": [{
-              "@attr": ["https://example.com/somepath"],
-              "person": [{
-                "@id": ["101"],
-                "phone": [122233344550, 122233344551],
-                "name": ["Jack"],
-                "age": [33],
-                "emptyNode": [""],
-                "booleanNode": [false, true],
-                "selfclosing": [
-                  "",
-                  {
-                    "@with": "value"
-                  }
-                ],
-                "married": [{
-                  "@firstTime": "No",
-                  "@attr": "val 2",
-                  "#_text": "Yes"
-                }],
-                "birthday": ["Wed, 28 Mar 1979 12:13:14 +0300"],
-                "address": [{
-                  "city": ["New York"],
-                  "street": ["Park Ave"],
-                  "buildingNo": [1],
-                  "flatNo": [1]
-                }, {
-                  "city": ["Boston"],
-                  "street": ["Centre St"],
-                  "buildingNo": [33],
-                  "flatNo": [24]
-                }]
-              }, {
-                "@id": ["102"],
-                "phone": [122233344553, 122233344554],
-                "name": ["Boris"],
-                "age": [34],
-                "married": [{
-                    "@firstTime": "Yes",
-                    "#_text": "Yes"
-                }],
-                "birthday": ["Mon, 31 Aug 1970 02:03:04 +0300"],
-                "address": [{
-                    "city": ["Moscow"],
-                    "street": ["Kahovka"],
-                    "buildingNo": [1],
-                    "flatNo": [2]
-                }, {
-                    "city": ["Tula"],
-                    "street": ["Lenina"],
-                    "buildingNo": [3],
-                    "flatNo": [78]
-                }]
-              }]
-            }]
-          };
-
-          const result = parser.parse(xmlData, {
+        const result = parser.parse(xmlData, {
             ignoreAttributes: false,
             ignoreNonTextNodeAttr: false,
             attributeNamePrefix: "@",
-            textNodeName: "#_text",
-            arrayMode: true
-          });
-          expect(result).toEqual(expected);
-        }); */
+            textNodeName: "#_text"
+        });
+        //console.log(JSON.stringify(result,null,4));
+        expect(result).toEqual(expected);
+    });
 
-        it("should skip namespace", function () {
-            const xmlData = `\
+    /* it("should parse nodes as arrays", function () {
+      const fs = require("fs");
+      const path = require("path");
+      const fileNamePath = path.join(__dirname, "assets/sample.xml");
+      const xmlData = fs.readFileSync(fileNamePath).toString();
+
+      const expected = {
+        "any_name": [{
+          "@attr": ["https://example.com/somepath"],
+          "person": [{
+            "@id": ["101"],
+            "phone": [122233344550, 122233344551],
+            "name": ["Jack"],
+            "age": [33],
+            "emptyNode": [""],
+            "booleanNode": [false, true],
+            "selfclosing": [
+              "",
+              {
+                "@with": "value"
+              }
+            ],
+            "married": [{
+              "@firstTime": "No",
+              "@attr": "val 2",
+              "#_text": "Yes"
+            }],
+            "birthday": ["Wed, 28 Mar 1979 12:13:14 +0300"],
+            "address": [{
+              "city": ["New York"],
+              "street": ["Park Ave"],
+              "buildingNo": [1],
+              "flatNo": [1]
+            }, {
+              "city": ["Boston"],
+              "street": ["Centre St"],
+              "buildingNo": [33],
+              "flatNo": [24]
+            }]
+          }, {
+            "@id": ["102"],
+            "phone": [122233344553, 122233344554],
+            "name": ["Boris"],
+            "age": [34],
+            "married": [{
+                "@firstTime": "Yes",
+                "#_text": "Yes"
+            }],
+            "birthday": ["Mon, 31 Aug 1970 02:03:04 +0300"],
+            "address": [{
+                "city": ["Moscow"],
+                "street": ["Kahovka"],
+                "buildingNo": [1],
+                "flatNo": [2]
+            }, {
+                "city": ["Tula"],
+                "street": ["Lenina"],
+                "buildingNo": [3],
+                "flatNo": [78]
+            }]
+          }]
+        }]
+      };
+
+      const result = parser.parse(xmlData, {
+        ignoreAttributes: false,
+        ignoreNonTextNodeAttr: false,
+        attributeNamePrefix: "@",
+        textNodeName: "#_text",
+        arrayMode: true
+      });
+      expect(result).toEqual(expected);
+    }); */
+
+    it("should skip namespace", function () {
+        const xmlData = `\
     <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/" >
         <soap-env:Header>
             <cor:applicationID>dashboardweb</cor:applicationID>
@@ -743,162 +744,162 @@ describe("XMLParser", function () {
             </man:getOffers>
         </soap-env:Body>
     </soap-env:Envelope>`;
-            const expected = {
-                "Envelope": {
-                    "Header": {
-                        "applicationID": "dashboardweb",
-                        "providerID": "abc"
-                    },
-                    "Body": {
-                        "getOffers": {
-                            "customerId": {
-                                "msisdn": 123456789
-                            }
+        const expected = {
+            "Envelope": {
+                "Header": {
+                    "applicationID": "dashboardweb",
+                    "providerID": "abc"
+                },
+                "Body": {
+                    "getOffers": {
+                        "customerId": {
+                            "msisdn": 123456789
                         }
                     }
                 }
-            };
+            }
+        };
 
-            const result = parser.parse(xmlData, { ignoreNameSpace: true });
-            expect(result).toEqual(expected);
+        const result = parser.parse(xmlData, { ignoreNameSpace: true });
+        expect(result).toEqual(expected);
+    });
+
+    it("should not trim tag value if not allowed ", function () {
+        const xmlData = "<rootNode>       123        </rootNode>";
+        const expected = {
+            "rootNode": "       123        "
+        };
+        const result = parser.parse(xmlData, {
+            parseNodeValue: false,
+            trimValues: false
         });
+        //console.log(JSON.stringify(result,null,4));
+        expect(result).toEqual(expected);
+    });
 
-        it("should not trim tag value if not allowed ", function () {
-            const xmlData = "<rootNode>       123        </rootNode>";
-            const expected = {
-                "rootNode": "       123        "
-            };
-            const result = parser.parse(xmlData, {
-                parseNodeValue: false,
-                trimValues: false
-            });
-            //console.log(JSON.stringify(result,null,4));
-            expect(result).toEqual(expected);
+    it("should not trim tag value but not parse if not allowed ", function () {
+        const xmlData = "<rootNode>       123        </rootNode>";
+        const expected = {
+            "rootNode": "123"
+        };
+        const result = parser.parse(xmlData, {
+            parseNodeValue: false
         });
+        //console.log(JSON.stringify(result,null,4));
+        expect(result).toEqual(expected);
+    });
 
-        it("should not trim tag value but not parse if not allowed ", function () {
-            const xmlData = "<rootNode>       123        </rootNode>";
-            const expected = {
-                "rootNode": "123"
-            };
-            const result = parser.parse(xmlData, {
-                parseNodeValue: false
-            });
-            //console.log(JSON.stringify(result,null,4));
-            expect(result).toEqual(expected);
+    it("should not decode HTML entities by default", function () {
+        const xmlData = "<rootNode>       foo&ampbar&apos;        </rootNode>";
+        const expected = {
+            "rootNode": "foo&ampbar&apos;"
+        };
+        const result = parser.parse(xmlData, {
+            parseNodeValue: false
         });
+        //console.log(JSON.stringify(result,null,4));
+        expect(result).toEqual(expected);
+    });
 
-        it("should not decode HTML entities by default", function () {
-            const xmlData = "<rootNode>       foo&ampbar&apos;        </rootNode>";
-            const expected = {
-                "rootNode": "foo&ampbar&apos;"
-            };
-            const result = parser.parse(xmlData, {
-                parseNodeValue: false
-            });
-            //console.log(JSON.stringify(result,null,4));
-            expect(result).toEqual(expected);
+    it("should parse XML with DOCTYPE", function () {
+        const xmlData = "<?xml version=\"1.0\" standalone=\"yes\" ?>" +
+            "<!--open the DOCTYPE declaration -" +
+            "  the open square bracket indicates an internal DTD-->" +
+            "<!DOCTYPE foo [" +
+            "<!--define the internal DTD-->" +
+            "<!ELEMENT foo (#PCDATA)>" +
+            "<!--close the DOCTYPE declaration-->" +
+            "]>" +
+            "<foo>Hello World.</foo>";
+
+        const expected = {
+            foo: "Hello World."
+        };
+        const result = parser.parse(xmlData, {
+            //parseNodeValue: false,
+            //trimValues: false
         });
+        //console.log(JSON.stringify(result,null,4));
+        expect(result).toEqual(expected);
+    });
 
-        it("should parse XML with DOCTYPE", function () {
-            const xmlData = "<?xml version=\"1.0\" standalone=\"yes\" ?>" +
-                "<!--open the DOCTYPE declaration -" +
-                "  the open square bracket indicates an internal DTD-->" +
-                "<!DOCTYPE foo [" +
-                "<!--define the internal DTD-->" +
-                "<!ELEMENT foo (#PCDATA)>" +
-                "<!--close the DOCTYPE declaration-->" +
-                "]>" +
-                "<foo>Hello World.</foo>";
+    //Issue #77
+    it("should parse node with space in closing node", function () {
+        const xmlData = "<?xml version='1.0'?>"
+            + "<any_name>"
+            + "    <person>"
+            + "        <name1>Jack 1</name1 >"
+            + "        <name2>Jack 2</name2>"
+            + "    </person>"
+            + "</any_name>";
 
-            const expected = {
-                foo: "Hello World."
-            };
-            const result = parser.parse(xmlData, {
-                //parseNodeValue: false,
-                //trimValues: false
-            });
-            //console.log(JSON.stringify(result,null,4));
-            expect(result).toEqual(expected);
-        });
-
-        //Issue #77
-        it("should parse node with space in closing node", function () {
-            const xmlData = "<?xml version='1.0'?>"
-                + "<any_name>"
-                + "    <person>"
-                + "        <name1>Jack 1</name1 >"
-                + "        <name2>Jack 2</name2>"
-                + "    </person>"
-                + "</any_name>";
-
-            const expected = {
-                "any_name": {
-                    "person": {
-                        "name1": "Jack 1",
-                        "name2": "Jack 2"
-                    }
+        const expected = {
+            "any_name": {
+                "person": {
+                    "name1": "Jack 1",
+                    "name2": "Jack 2"
                 }
-            };
-            const result = parser.parse(xmlData);
-            //console.log(JSON.stringify(result,null,4));
-            expect(result).toEqual(expected);
-        });
+            }
+        };
+        const result = parser.parse(xmlData);
+        //console.log(JSON.stringify(result,null,4));
+        expect(result).toEqual(expected);
+    });
 
-        it("should parse node with text before, after and between of subtags", function () {
-            const xmlData = "<?xml version='1.0'?>"
-                + "<tag>before"
-                + "    <subtag>subtag text</subtag>"
-                + "    middle"
-                + "    <self />"
-                + "    after self"
-                + "    <subtag2>subtag text</subtag2>"
-                + "    after"
-                + "</tag>";
+    it("should parse node with text before, after and between of subtags", function () {
+        const xmlData = "<?xml version='1.0'?>"
+            + "<tag>before"
+            + "    <subtag>subtag text</subtag>"
+            + "    middle"
+            + "    <self />"
+            + "    after self"
+            + "    <subtag2>subtag text</subtag2>"
+            + "    after"
+            + "</tag>";
 
-            const expected = {
-                "tag": {
-                    "#text": "before        middle        after self        after",
-                    "subtag": "subtag text",
-                    "self": "",
-                    "subtag2": "subtag text"
-                }
-            };
+        const expected = {
+            "tag": {
+                "#text": "before        middle        after self        after",
+                "subtag": "subtag text",
+                "self": "",
+                "subtag2": "subtag text"
+            }
+        };
 
-            var result = validator.validate(xmlData);
-            expect(result).toBe(true);
+        var result = validator.validate(xmlData);
+        expect(result).toBe(true);
 
-            result = parser.parse(xmlData, { trimValues: false });
-            //console.log(JSON.stringify(result,null,4));
-            expect(result).toEqual(expected);
-        });
+        result = parser.parse(xmlData, { trimValues: false });
+        //console.log(JSON.stringify(result,null,4));
+        expect(result).toEqual(expected);
+    });
 
-        it("should validate before parsing", function () {
-            const xmlData = "<?xml version='1.0'?>"
-                + "<tag>"
-                + "    <subtag2>subtag text</subtag2>"
-                + "</tag";
+    it("should validate before parsing", function () {
+        const xmlData = "<?xml version='1.0'?>"
+            + "<tag>"
+            + "    <subtag2>subtag text</subtag2>"
+            + "</tag";
 
         expect(() => {
             parser.parse(xmlData,{trimValues:true}, true);
         }).toThrowError(`Closing tag 'tag' doesn't have proper closing.`)
 
-        });
+    });
 
-        it("should validate with options before parsing", function () {
-            const xmlData = "<?xml version='1.0'?>"
-                + "<tag foo>"
-                + "    <subtag2>subtag text</subtag2>"
-                + "</tag>";
+    it("should validate with options before parsing", function () {
+        const xmlData = "<?xml version='1.0'?>"
+            + "<tag foo>"
+            + "    <subtag2>subtag text</subtag2>"
+            + "</tag>";
 
-            const expected = {
-                "tag": {
-                    "subtag2": "subtag text"
-                }
-            };
+        const expected = {
+            "tag": {
+                "subtag2": "subtag text"
+            }
+        };
 
-            let result = parser.parse(xmlData, { trimValues: true }, { allowBooleanAttributes: true });
-            //console.log(JSON.stringify(result,null,4));
-            expect(result).toEqual(expected);
-        });
+        let result = parser.parse(xmlData, { trimValues: true }, { allowBooleanAttributes: true });
+        //console.log(JSON.stringify(result,null,4));
+        expect(result).toEqual(expected);
+    });
 });

--- a/spec/xmlParser_spec.js
+++ b/spec/xmlParser_spec.js
@@ -3,769 +3,902 @@
 const parser = require("../src/parser");
 const validator = require("../src/validator");
 
-describe("XMLParser", function() {
+describe("XMLParser", function () {
 
-    it("should parse all values as string, int, boolean, float, hexadecimal", function() {
-        const xmlData = `<rootNode>
-        <tag>value</tag>
-        <boolean>true</boolean>
-        <intTag>045</intTag>
+    it("should preserve the position of tags when specified", function () {
+        const xmlData = `<store> locates in
+                <region>US</region>
+                and
+                <region>Japan</region>
+                only
+        </store>`
+
+        const expected = {
+            "store": [{
+                "": [
+                    { "#text": "locates in" },
+                    { "region": "US" },
+                    { "#text": "and" },
+                    { "region": "Japan" },
+                    { "#text": "only" }
+                ]
+            }]
+        }
+
+        const result = parser.parse(xmlData, { arrayMode: true, preserveOrder: true });
+        //console.log(JSON.stringify(result, null, 4));
+        expect(result).toEqual(expected);
+    })
+
+    it("should only preserve the position of text nodes when specified", function () {
+        const xmlData = `
+        <root>
+            <store> locates in
+                    <region>US</region>
+                    and
+                    <region>Japan</region>
+                    only
+            </store>
+            <second>
+                <a>1</a>
+                <b>2</b>
+                <a>3</a>
+            </second>
+        </root>`
+
+        const expected = {
+            root: [{
+                store: [{
+                    "": [
+                        { "#text": "locates in" },
+                        { "region": "US" },
+                        { "#text": "and" },
+                        { "region": "Japan" },
+                        { "#text": "only" }
+                    ]
+                }],
+                second: [{
+                    a: [1, 3],
+                    b: 2
+                }]
+            }]
+        }
+
+        const result = parser.parse(xmlData, { arrayMode: true, preserveOrder: "text" });
+//        console.log(JSON.stringify(result, null, 4));
+        expect(result).toEqual(expected);
+    })
+
+    it("should preserve the position of all nodes when specified", function () {
+        const xmlData = `
+        <root>
+            <store> locates in
+                    <region>US</region>
+                    and
+                    <region>Japan</region>
+                    only
+            </store>
+            <second>
+                <a>1</a>
+                <b>2</b>
+                <a>3</a>
+            </second>
+        </root>`
+
+        const expected = {
+            root: [{
+                "": [
+                    {
+                        store: {
+                            "": [
+                                { "#text": "locates in" },
+                                { "region": "US" },
+                                { "#text": "and" },
+                                { "region": "Japan" },
+                                { "#text": "only" }
+                            ]
+                        }
+                    },
+                    {
+                        second: {
+                            "": [{ a: 1 }, { b: 2 }, { a: 3 }]
+                        }
+                    }
+                ]
+            }]
+        }
+
+        const result = parser.parse(xmlData, { arrayMode: true, preserveOrder: true });
+        //console.log(JSON.stringify(result, null, 4));
+        expect(result).toEqual(expected);
+    })
+
+        it("should ignore the position of tags by default", function () {
+            const xmlData = `<store> locates in
+                    <region>US</region>
+                    and
+                    <region>Japan</region>
+                    only
+            </store>`
+
+            const expected = {
+                "store": [
+                    {
+                        "#text": "locates inandonly",
+                        "region": [
+                            "US",
+                            "Japan"
+                        ]
+                    }
+                ]
+            }
+
+            const result = parser.parse(xmlData, { arrayMode: true });
+            //console.log(JSON.stringify(result, null, 4));
+            expect(result).toEqual(expected);
+        })
+
+        it("should parse all values as string, int, boolean, float, hexadecimal", function () {
+            const xmlData = `<rootNode>
+            <tag>value</tag>
+            <boolean>true</boolean>
+            <intTag>045</intTag>
+            <floatTag>65.340</floatTag>
+            <hexadecimal>0x15</hexadecimal>
+            </rootNode>`;
+            const expected = {
+                "rootNode": {
+                    "tag": "value",
+                    "boolean": true,
+                    "intTag": 45,
+                    "floatTag": 65.34,
+                    "hexadecimal": 21
+                }
+            };
+
+            const result = parser.parse(xmlData);
+            //console.log(JSON.stringify(result,null,4));
+            expect(result).toEqual(expected);
+        });
+
+
+        it("should parse only true numbers", function () {
+            const xmlData = `<rootNode>
+            <tag>value</tag>
+            <boolean>true</boolean>
+            <intTag>045</intTag>
+            <floatTag>65.34</floatTag>
+            <long>420926189200190257681175017717</long>
+            </rootNode>`;
+            const expected = {
+                "rootNode": {
+                    "tag": "value",
+                    "boolean": true,
+                    "intTag": "045",
+                    "floatTag": 65.34,
+                    "long": "420926189200190257681175017717"
+                }
+            };
+
+            const result = parser.parse(xmlData, {
+                parseTrueNumberOnly: true
+            });
+            //console.log(JSON.stringify(result,null,4));
+            expect(result).toEqual(expected);
+        });
+
+        it("should not parse values to primitive type", function () {
+            const xmlData = `<rootNode><tag>value</tag><boolean>true</boolean><intTag>045</intTag><floatTag>65.34</floatTag></rootNode>`;
+            const expected = {
+                "rootNode": {
+                    "tag": "value",
+                    "boolean": "true",
+                    "intTag": "045",
+                    "floatTag": "65.34"
+                }
+            };
+
+            const result = parser.parse(xmlData, {
+                parseNodeValue: false
+            });
+            expect(result).toEqual(expected);
+        });
+
+        it("should parse number values of attributes as number", function () {
+            const xmlData = `<rootNode><tag int='045' intNegative='-045' float='65.34' floatNegative='-65.34'>value</tag></rootNode>`;
+            const expected = {
+                "rootNode": {
+                    "tag": {
+                        "#text": "value",
+                        "@_int": 45,
+                        "@_intNegative": -45,
+                        "@_float": 65.34,
+                        "@_floatNegative": -65.34
+                    }
+                }
+            };
+
+            const result = parser.parse(xmlData, {
+                ignoreAttributes: false,
+                parseAttributeValue: true
+            });
+
+            expect(result).toEqual(expected);
+        });
+
+        it("should parse number values as number if flag is set", function () {
+            const xmlData = `<rootNode><tag>value</tag><intTag>045</intTag><intTag>0</intTag><floatTag>65.34</floatTag></rootNode>`;
+            const expected = {
+                "rootNode": {
+                    "tag": "value",
+                    "intTag": [45, 0],
+                    "floatTag": 65.34
+                }
+            };
+
+            const result = parser.parse(xmlData, {
+                parseNodeValue: true
+            });
+            expect(result).toEqual(expected);
+        });
+
+        it("should skip tag arguments", function () {
+            const xmlData = `<rootNode><tag ns:arg='value'>value</tag><intTag ns:arg='value' ns:arg2='value2' >45</intTag><floatTag>65.34</floatTag></rootNode>`;
+            const expected = {
+                "rootNode": {
+                    "tag": "value",
+                    "intTag": 45,
+                    "floatTag": 65.34
+                }
+            };
+
+            const result = parser.parse(xmlData);
+            expect(result).toEqual(expected);
+        });
+
+        it("should ignore namespace and text node attributes", function () {
+            const xmlData = `\
+    <root:node>
+        <tag ns:arg='value'>value</tag>
+        <intTag ns:arg='value' ns:arg2='value2' >45</intTag>
         <floatTag>65.34</floatTag>
-        <hexadecimal>0x15</hexadecimal>
-        </rootNode>`;
-        const expected = {
-            "rootNode": {
-                "tag":      "value",
-                "boolean":  true,
-                "intTag":   45,
-                "floatTag": 65.34,
-                "hexadecimal" : 21
-            }
-        };
+        <nsTag xmlns:tns-ns='urn:none' tns-ns:attr='tns'></nsTag>
+        <nsTagNoAttr xmlns:tns-ns='urn:none'></nsTagNoAttr>
+    </root:node>`;
 
-        const result = parser.parse(xmlData);
-        //console.log(JSON.stringify(result,null,4));
-        expect(result).toEqual(expected);
-    });
-
-
-    it("should parse only true numbers", function() {
-        const xmlData = `<rootNode>
-        <tag>value</tag>
-        <boolean>true</boolean>
-        <intTag>045</intTag>
-        <floatTag>65.340</floatTag>
-        <long>420926189200190257681175017717</long>
-        </rootNode>`;
-        const expected = {
-            "rootNode": {
-                "tag":      "value",
-                "boolean":  true,
-                "intTag":   "045",
-                "floatTag": 65.34,
-                "long": "420926189200190257681175017717"
-            }
-        };
-
-        const result = parser.parse(xmlData, {
-            parseTrueNumberOnly : true
-        });
-        //console.log(JSON.stringify(result,null,4));
-        expect(result).toEqual(expected);
-    });
-
-    it("should not parse values to primitive type", function() {
-        const xmlData = `<rootNode><tag>value</tag><boolean>true</boolean><intTag>045</intTag><floatTag>65.34</floatTag></rootNode>`;
-        const expected = {
-            "rootNode": {
-                "tag":      "value",
-                "boolean":  "true",
-                "intTag":   "045",
-                "floatTag": "65.34"
-            }
-        };
-
-        const result = parser.parse(xmlData, {
-            parseNodeValue: false
-        });
-        expect(result).toEqual(expected);
-    });
-
-    it("should parse number values of attributes as number", function() {
-        const xmlData = `<rootNode><tag int='045' intNegative='-045' float='65.34' floatNegative='-65.34'>value</tag></rootNode>`;
-        const expected = {
-            "rootNode": {
-                "tag": {
-                    "#text":   "value",
-                    "@_int":   45,
-                    "@_intNegative":   -45,
-                    "@_float": 65.34,
-                    "@_floatNegative": -65.34
+            const expected = {
+                "node": {
+                    "tag": {
+                        "@_arg": "value",
+                        "#text": "value"
+                    },
+                    "intTag": {
+                        "@_arg": "value",
+                        "@_arg2": "value2",
+                        "#text": 45
+                    },
+                    "floatTag": 65.34,
+                    "nsTag": {
+                        "@_attr": "tns"
+                        //"#text": ""
+                    },
+                    "nsTagNoAttr": ""
                 }
-            }
-        };
+            };
 
-        const result = parser.parse(xmlData, {
-            ignoreAttributes:    false,
-            parseAttributeValue: true
+            const result = parser.parse(xmlData, {
+                ignoreNameSpace: true,
+                ignoreAttributes: false
+            });
+
+            expect(result).toEqual(expected);
         });
 
-        expect(result).toEqual(expected);
-    });
-
-    it("should parse number values as number if flag is set", function() {
-        const xmlData = `<rootNode><tag>value</tag><intTag>045</intTag><intTag>0</intTag><floatTag>65.34</floatTag></rootNode>`;
-        const expected = {
-            "rootNode": {
-                "tag":      "value",
-                "intTag":   [45, 0],
-                "floatTag": 65.34
-            }
-        };
-
-        const result = parser.parse(xmlData, {
-            parseNodeValue: true
-        });
-        expect(result).toEqual(expected);
-    });
-
-    it("should skip tag arguments", function() {
-        const xmlData = `<rootNode><tag ns:arg='value'>value</tag><intTag ns:arg='value' ns:arg2='value2' >45</intTag><floatTag>65.34</floatTag></rootNode>`;
-        const expected = {
-            "rootNode": {
-                "tag":      "value",
-                "intTag":   45,
-                "floatTag": 65.34
-            }
-        };
-
-        const result = parser.parse(xmlData);
-        expect(result).toEqual(expected);
-    });
-
-    it("should ignore namespace and text node attributes", function() {
-        const xmlData = `\
-<root:node>
-    <tag ns:arg='value'>value</tag>
-    <intTag ns:arg='value' ns:arg2='value2' >45</intTag>
-    <floatTag>65.34</floatTag>
-    <nsTag xmlns:tns-ns='urn:none' tns-ns:attr='tns'></nsTag>
-    <nsTagNoAttr xmlns:tns-ns='urn:none'></nsTagNoAttr>
-</root:node>`;
-
-        const expected = {
-            "node": {
-                "tag":         {
-                    "@_arg": "value",
-                    "#text": "value"
-                },
-                "intTag":      {
-                    "@_arg":  "value",
-                    "@_arg2": "value2",
-                    "#text":  45
-                },
-                "floatTag":    65.34,
-                "nsTag":       {
-                    "@_attr": "tns"
-                    //"#text": ""
-                },
-                "nsTagNoAttr": ""
-            }
-        };
-
-        const result = parser.parse(xmlData, {
-            ignoreNameSpace:  true,
-            ignoreAttributes: false
-        });
-
-        expect(result).toEqual(expected);
-    });
-
-    it("should parse empty text Node", function() {
-        const xmlData = `<rootNode><tag></tag></rootNode>`;
-        const expected = {
-            "rootNode": {
-                "tag": ""
-            }
-        };
-
-        const result = parser.parse(xmlData);
-        expect(result).toEqual(expected);
-    });
-
-    it("should parse self closing tags", function() {
-        const xmlData = "<rootNode><tag ns:arg='value'/></rootNode>";
-        const expected = {
-            "rootNode": {
-                "tag": {
-                    "@_ns:arg": "value"
+        it("should parse empty text Node", function () {
+            const xmlData = `<rootNode><tag></tag></rootNode>`;
+            const expected = {
+                "rootNode": {
+                    "tag": ""
                 }
-            }
-        };
+            };
 
-        const result = parser.parse(xmlData, {
-            ignoreAttributes: false
+            const result = parser.parse(xmlData);
+            expect(result).toEqual(expected);
         });
-        expect(result).toEqual(expected);
-    });
 
-    it("should parse single self closing tag", function() {
-        const xmlData = `<tag arg='value'/>`;
-        const expected = {
-            "tag": {
-                "@_arg": "value"
-            }
-        };
+        it("should parse self closing tags", function () {
+            const xmlData = "<rootNode><tag ns:arg='value'/></rootNode>";
+            const expected = {
+                "rootNode": {
+                    "tag": {
+                        "@_ns:arg": "value"
+                    }
+                }
+            };
 
-        //console.log(parser.getTraversalObj(xmlData));
-        const result = parser.parse(xmlData, {
-            ignoreAttributes: false
+            const result = parser.parse(xmlData, {
+                ignoreAttributes: false
+            });
+            expect(result).toEqual(expected);
         });
-        expect(result).toEqual(expected);
-    });
 
-    it("should parse repeated nodes in array", function() {
-        const xmlData = `\
-<rootNode>
-    <tag>value</tag>
-    <tag>45</tag>
-    <tag>65.34</tag>
-</rootNode>`;
-        const expected = {
-            "rootNode": {
-                "tag": ["value", 45, 65.34]
-            }
-        };
+        it("should parse single self closing tag", function () {
+            const xmlData = `<tag arg='value'/>`;
+            const expected = {
+                "tag": {
+                    "@_arg": "value"
+                }
+            };
 
-        const result = parser.parse(xmlData);
-        expect(result).toEqual(expected);
-    });
+            //console.log(parser.getTraversalObj(xmlData));
+            const result = parser.parse(xmlData, {
+                ignoreAttributes: false
+            });
+            expect(result).toEqual(expected);
+        });
 
-    it("should parse nested nodes in nested properties", function() {
-        const xmlData = `\
-<rootNode>
-    <parenttag>
+        it("should parse repeated nodes in array", function () {
+            const xmlData = `\
+    <rootNode>
         <tag>value</tag>
         <tag>45</tag>
         <tag>65.34</tag>
-    </parenttag>
-</rootNode>`;
-        const expected = {
-            "rootNode": {
-                "parenttag": {
+    </rootNode>`;
+            const expected = {
+                "rootNode": {
                     "tag": ["value", 45, 65.34]
                 }
-            }
-        };
+            };
 
-        const result = parser.parse(xmlData);
-        expect(result).toEqual(expected);
-    });
-
-    it("should parse non-text nodes with value for repeated nodes", function() {
-        const xmlData = `
-<rootNode>
-    <parenttag attr1='some val' attr2='another val'>
-        <tag>value</tag>
-        <tag attr1='val' attr2='234'>45</tag>
-        <tag>65.34</tag>
-    </parenttag>
-    <parenttag attr1='some val' attr2='another val'>
-        <tag>value</tag>
-        <tag attr1='val' attr2='234'>45</tag>
-        <tag>65.34</tag>
-    </parenttag>
-</rootNode>`;
-        const expected = {
-            "rootNode": {
-                "parenttag": [
-                    {
-                        "@_attr1": "some val",
-                        "@_attr2": "another val",
-                        "tag":     [
-                            "value",
-                            {
-                                "@_attr1": "val",
-                                "@_attr2": "234",
-                                "#text":   45
-                            },
-                            65.34
-                        ]
-                    }, {
-                        "@_attr1": "some val",
-                        "@_attr2": "another val",
-                        "tag":     [
-                            "value",
-                            {
-                                "@_attr1": "val",
-                                "@_attr2": "234",
-                                "#text":   45
-                            },
-                            65.34
-                        ]
-                    }
-                ]
-            }
-        };
-
-        const result = parser.parse(xmlData, {
-            ignoreAttributes: false
+            const result = parser.parse(xmlData);
+            expect(result).toEqual(expected);
         });
-        expect(result).toEqual(expected);
-    });
 
-    it("should preserve node value", function() {
-        const xmlData = `<rootNode attr1=' some val ' name='another val'> some val </rootNode>`;
-        const expected = {
-            "rootNode": {
-                "@_attr1": " some val ",
-                "@_name":  "another val",
-                "#text":   " some val "
-            }
-        };
+        it("should parse nested nodes in nested properties", function () {
+            const xmlData = `\
+    <rootNode>
+        <parenttag>
+            <tag>value</tag>
+            <tag>45</tag>
+            <tag>65.34</tag>
+        </parenttag>
+    </rootNode>`;
+            const expected = {
+                "rootNode": {
+                    "parenttag": {
+                        "tag": ["value", 45, 65.34]
+                    }
+                }
+            };
 
-        const result = parser.parse(xmlData, {
+            const result = parser.parse(xmlData);
+            expect(result).toEqual(expected);
+        });
+
+        it("should parse non-text nodes with value for repeated nodes", function () {
+            const xmlData = `
+    <rootNode>
+        <parenttag attr1='some val' attr2='another val'>
+            <tag>value</tag>
+            <tag attr1='val' attr2='234'>45</tag>
+            <tag>65.34</tag>
+        </parenttag>
+        <parenttag attr1='some val' attr2='another val'>
+            <tag>value</tag>
+            <tag attr1='val' attr2='234'>45</tag>
+            <tag>65.34</tag>
+        </parenttag>
+    </rootNode>`;
+            const expected = {
+                "rootNode": {
+                    "parenttag": [
+                        {
+                            "@_attr1": "some val",
+                            "@_attr2": "another val",
+                            "tag": [
+                                "value",
+                                {
+                                    "@_attr1": "val",
+                                    "@_attr2": "234",
+                                    "#text": 45
+                                },
+                                65.34
+                            ]
+                        }, {
+                            "@_attr1": "some val",
+                            "@_attr2": "another val",
+                            "tag": [
+                                "value",
+                                {
+                                    "@_attr1": "val",
+                                    "@_attr2": "234",
+                                    "#text": 45
+                                },
+                                65.34
+                            ]
+                        }
+                    ]
+                }
+            };
+
+            const result = parser.parse(xmlData, {
+                ignoreAttributes: false
+            });
+            expect(result).toEqual(expected);
+        });
+
+        it("should preserve node value", function () {
+            const xmlData = `<rootNode attr1=' some val ' name='another val'> some val </rootNode>`;
+            const expected = {
+                "rootNode": {
+                    "@_attr1": " some val ",
+                    "@_name": "another val",
+                    "#text": " some val "
+                }
+            };
+
+            const result = parser.parse(xmlData, {
+                ignoreAttributes: false,
+                trimValues: false
+            });
+            expect(result).toEqual(expected);
+        });
+
+        it("should parse with attributes and value when there is single node", function () {
+            const xmlData = `<rootNode attr1='some val' attr2='another val'>val</rootNode>`;
+            const expected = {
+                "rootNode": {
+                    "@_attr1": "some val",
+                    "@_attr2": "another val",
+                    "#text": "val"
+                }
+            };
+
+            const result = parser.parse(xmlData, {
+                ignoreAttributes: false
+            });
+            expect(result).toEqual(expected);
+        });
+
+        it("should parse different tags", function () {
+            const xmlData = `<tag.1>val1</tag.1><tag.2>val2</tag.2>`;
+            const expected = {
+                "tag.1": "val1",
+                "tag.2": "val2"
+            };
+
+            const result = parser.parse(xmlData, {
+                ignoreAttributes: false
+            });
+            expect(result).toEqual(expected);
+        });
+
+        it("should not parse text value with tag", function () {
+            const xmlData = `<score><c1>71<message>23</message>29</c1></score>`;
+            const expected = {
+                "score": {
+                    "c1": {
+                        "message": 23,
+                        "_text": "7129"
+                    }
+                }
+            };
+
+            const result = parser.parse(xmlData, {
+                textNodeName: "_text",
+                ignoreAttributes: false
+            });
+
+            expect(result).toEqual(expected);
+        });
+
+        it("should parse nested elements with attributes", function () {
+            const xmlData = `\
+    <root>
+        <Meet date="2017-05-03" type="A" name="Meeting 'A'">
+            <Event time="00:05:00" ID="574" Name="Some Event Name">
+                <User ID="1">Bob</User>
+            </Event>
+        </Meet>
+    </root>`;
+            const expected = {
+                "root": {
+                    "Meet": {
+                        "@_date": "2017-05-03",
+                        "@_type": "A",
+                        "@_name": "Meeting 'A'",
+                        "Event": {
+                            "@_time": "00:05:00",
+                            "@_ID": "574",
+                            "@_Name": "Some Event Name",
+                            "User": {
+                                "@_ID": "1",
+                                "#text": "Bob"
+                            }
+                        }
+                    }
+                }
+            };
+
+            const result = parser.parse(xmlData, {
+                ignoreAttributes: false,
+                ignoreNonTextNodeAttr: false
+            });
+
+            expect(result).toEqual(expected);
+        });
+
+        it("should parse nested elements with attributes wrapped in object", function () {
+            const xmlData = `\
+    <root xmlns="urn:none" xmlns:tns-ns="urn:none">
+        <Meet xmlns="urn:none" tns-ns:nsattr="attr" date="2017-05-03" type="A" name="Meeting 'A'">
+            <Event time="00:05:00" ID="574" Name="Some Event Name">
+                <User ID="1">Bob</User>
+            </Event>
+        </Meet>
+    </root>`;
+            const expected = {
+                "root": {
+                    "Meet": {
+                        "$": {
+                            "nsattr": "attr",
+                            "date": "2017-05-03",
+                            "type": "A",
+                            "name": "Meeting 'A'"
+                        },
+                        "Event": {
+                            "$": {
+                                "time": "00:05:00",
+                                "ID": "574",
+                                "Name": "Some Event Name"
+                            },
+                            "User": {
+                                "$": {
+                                    "ID": "1"
+                                },
+                                "#text": "Bob"
+                            }
+                        }
+                    }
+                }
+            };
+
+            const result = parser.parse(xmlData, {
+                attributeNamePrefix: "",
+                attrNodeName: "$",
+                ignoreNameSpace: true,
+                ignoreAttributes: false
+            });
+
+            //console.log(JSON.stringify(result,null,4));
+            expect(result).toEqual(expected);
+        });
+
+        it("should parse all type of nodes", function () {
+            const fs = require("fs");
+            const path = require("path");
+            const fileNamePath = path.join(__dirname, "assets/sample.xml");
+            const xmlData = fs.readFileSync(fileNamePath).toString();
+
+            const expected = {
+                "any_name": {
+                    "@attr": "https://example.com/somepath",
+                    "person": [
+                        {
+                            "@id": "101",
+                            "phone": [122233344550, 122233344551],
+                            "name": "Jack",
+                            "age": 33,
+                            "emptyNode": "",
+                            "booleanNode": [false, true],
+                            "selfclosing": [
+                                "",
+                                {
+                                    "@with": "value"
+                                }
+                            ],
+                            "married": {
+                                "@firstTime": "No",
+                                "@attr": "val 2",
+                                "#_text": "Yes"
+                            },
+                            "birthday": "Wed, 28 Mar 1979 12:13:14 +0300",
+                            "address": [
+                                {
+                                    "city": "New York",
+                                    "street": "Park Ave",
+                                    "buildingNo": 1,
+                                    "flatNo": 1
+                                }, {
+                                    "city": "Boston",
+                                    "street": "Centre St",
+                                    "buildingNo": 33,
+                                    "flatNo": 24
+                                }
+                            ]
+                        }, {
+                            "@id": "102",
+                            "phone": [122233344553, 122233344554],
+                            "name": "Boris",
+                            "age": 34,
+                            "married": {
+                                "@firstTime": "Yes",
+                                "#_text": "Yes"
+                            },
+                            "birthday": "Mon, 31 Aug 1970 02:03:04 +0300",
+                            "address": [
+                                {
+                                    "city": "Moscow",
+                                    "street": "Kahovka",
+                                    "buildingNo": 1,
+                                    "flatNo": 2
+                                }, {
+                                    "city": "Tula",
+                                    "street": "Lenina",
+                                    "buildingNo": 3,
+                                    "flatNo": 78
+                                }
+                            ]
+                        }
+                    ]
+                }
+            };
+
+            const result = parser.parse(xmlData, {
+                ignoreAttributes: false,
+                ignoreNonTextNodeAttr: false,
+                attributeNamePrefix: "@",
+                textNodeName: "#_text"
+            });
+            //console.log(JSON.stringify(result,null,4));
+            expect(result).toEqual(expected);
+        });
+
+        /* it("should parse nodes as arrays", function () {
+          const fs = require("fs");
+          const path = require("path");
+          const fileNamePath = path.join(__dirname, "assets/sample.xml");
+          const xmlData = fs.readFileSync(fileNamePath).toString();
+
+          const expected = {
+            "any_name": [{
+              "@attr": ["https://example.com/somepath"],
+              "person": [{
+                "@id": ["101"],
+                "phone": [122233344550, 122233344551],
+                "name": ["Jack"],
+                "age": [33],
+                "emptyNode": [""],
+                "booleanNode": [false, true],
+                "selfclosing": [
+                  "",
+                  {
+                    "@with": "value"
+                  }
+                ],
+                "married": [{
+                  "@firstTime": "No",
+                  "@attr": "val 2",
+                  "#_text": "Yes"
+                }],
+                "birthday": ["Wed, 28 Mar 1979 12:13:14 +0300"],
+                "address": [{
+                  "city": ["New York"],
+                  "street": ["Park Ave"],
+                  "buildingNo": [1],
+                  "flatNo": [1]
+                }, {
+                  "city": ["Boston"],
+                  "street": ["Centre St"],
+                  "buildingNo": [33],
+                  "flatNo": [24]
+                }]
+              }, {
+                "@id": ["102"],
+                "phone": [122233344553, 122233344554],
+                "name": ["Boris"],
+                "age": [34],
+                "married": [{
+                    "@firstTime": "Yes",
+                    "#_text": "Yes"
+                }],
+                "birthday": ["Mon, 31 Aug 1970 02:03:04 +0300"],
+                "address": [{
+                    "city": ["Moscow"],
+                    "street": ["Kahovka"],
+                    "buildingNo": [1],
+                    "flatNo": [2]
+                }, {
+                    "city": ["Tula"],
+                    "street": ["Lenina"],
+                    "buildingNo": [3],
+                    "flatNo": [78]
+                }]
+              }]
+            }]
+          };
+
+          const result = parser.parse(xmlData, {
             ignoreAttributes: false,
-            trimValues:       false
-        });
-        expect(result).toEqual(expected);
-    });
-
-    it("should parse with attributes and value when there is single node", function() {
-        const xmlData = `<rootNode attr1='some val' attr2='another val'>val</rootNode>`;
-        const expected = {
-            "rootNode": {
-                "@_attr1": "some val",
-                "@_attr2": "another val",
-                "#text":   "val"
-            }
-        };
-
-        const result = parser.parse(xmlData, {
-            ignoreAttributes: false
-        });
-        expect(result).toEqual(expected);
-    });
-
-    it("should parse different tags", function() {
-        const xmlData = `<tag.1>val1</tag.1><tag.2>val2</tag.2>`;
-        const expected = {
-            "tag.1": "val1",
-            "tag.2": "val2"
-        };
-
-        const result = parser.parse(xmlData, {
-            ignoreAttributes: false
-        });
-        expect(result).toEqual(expected);
-    });
-
-    it("should not parse text value with tag", function() {
-        const xmlData = `<score><c1>71<message>23</message>29</c1></score>`;
-        const expected = {
-            "score": {
-                "c1": {
-                    "message": 23,
-                    "_text":   "7129"
-                }
-            }
-        };
-
-        const result = parser.parse(xmlData, {
-            textNodeName:     "_text",
-            ignoreAttributes: false
-        });
-
-        expect(result).toEqual(expected);
-    });
-
-    it("should parse nested elements with attributes", function() {
-        const xmlData = `\
-<root>
-    <Meet date="2017-05-03" type="A" name="Meeting 'A'">
-        <Event time="00:05:00" ID="574" Name="Some Event Name">
-            <User ID="1">Bob</User>
-        </Event>
-    </Meet>
-</root>`;
-        const expected = {
-            "root": {
-                "Meet": {
-                    "@_date": "2017-05-03",
-                    "@_type": "A",
-                    "@_name": "Meeting 'A'",
-                    "Event":  {
-                        "@_time": "00:05:00",
-                        "@_ID":   "574",
-                        "@_Name": "Some Event Name",
-                        "User":   {
-                            "@_ID":  "1",
-                            "#text": "Bob"
-                        }
-                    }
-                }
-            }
-        };
-
-        const result = parser.parse(xmlData, {
-            ignoreAttributes:      false,
-            ignoreNonTextNodeAttr: false
-        });
-
-        expect(result).toEqual(expected);
-    });
-
-    it("should parse nested elements with attributes wrapped in object", function() {
-        const xmlData = `\
-<root xmlns="urn:none" xmlns:tns-ns="urn:none">
-    <Meet xmlns="urn:none" tns-ns:nsattr="attr" date="2017-05-03" type="A" name="Meeting 'A'">
-        <Event time="00:05:00" ID="574" Name="Some Event Name">
-            <User ID="1">Bob</User>
-        </Event>
-    </Meet>
-</root>`;
-        const expected = {
-            "root": {
-                "Meet": {
-                    "$":     {
-                        "nsattr": "attr",
-                        "date":   "2017-05-03",
-                        "type":   "A",
-                        "name":   "Meeting 'A'"
-                    },
-                    "Event": {
-                        "$":    {
-                            "time": "00:05:00",
-                            "ID":   "574",
-                            "Name": "Some Event Name"
-                        },
-                        "User": {
-                            "$":     {
-                                "ID": "1"
-                            },
-                            "#text": "Bob"
-                        }
-                    }
-                }
-            }
-        };
-
-        const result = parser.parse(xmlData, {
-            attributeNamePrefix: "",
-            attrNodeName:        "$",
-            ignoreNameSpace:     true,
-            ignoreAttributes:    false
-        });
-
-        //console.log(JSON.stringify(result,null,4));
-        expect(result).toEqual(expected);
-    });
-
-    it("should parse all type of nodes", function() {
-        const fs = require("fs");
-        const path = require("path");
-        const fileNamePath = path.join(__dirname, "assets/sample.xml");
-        const xmlData = fs.readFileSync(fileNamePath).toString();
-
-        const expected = {
-            "any_name": {
-                "@attr":  "https://example.com/somepath",
-                "person": [
-                    {
-                        "@id":         "101",
-                        "phone":       [122233344550, 122233344551],
-                        "name":        "Jack",
-                        "age":         33,
-                        "emptyNode":   "",
-                        "booleanNode": [false, true],
-                        "selfclosing": [
-                            "",
-                            {
-                                "@with": "value"
-                            }
-                        ],
-                        "married":     {
-                            "@firstTime": "No",
-                            "@attr":      "val 2",
-                            "#_text":     "Yes"
-                        },
-                        "birthday":    "Wed, 28 Mar 1979 12:13:14 +0300",
-                        "address":     [
-                            {
-                                "city":       "New York",
-                                "street":     "Park Ave",
-                                "buildingNo": 1,
-                                "flatNo":     1
-                            }, {
-                                "city":       "Boston",
-                                "street":     "Centre St",
-                                "buildingNo": 33,
-                                "flatNo":     24
-                            }
-                        ]
-                    }, {
-                        "@id":      "102",
-                        "phone":    [122233344553, 122233344554],
-                        "name":     "Boris",
-                        "age":      34,
-                        "married":  {
-                            "@firstTime": "Yes",
-                            "#_text":     "Yes"
-                        },
-                        "birthday": "Mon, 31 Aug 1970 02:03:04 +0300",
-                        "address":  [
-                            {
-                                "city":       "Moscow",
-                                "street":     "Kahovka",
-                                "buildingNo": 1,
-                                "flatNo":     2
-                            }, {
-                                "city":       "Tula",
-                                "street":     "Lenina",
-                                "buildingNo": 3,
-                                "flatNo":     78
-                            }
-                        ]
-                    }
-                ]
-            }
-        };
-
-        const result = parser.parse(xmlData, {
-            ignoreAttributes:      false,
             ignoreNonTextNodeAttr: false,
-            attributeNamePrefix:   "@",
-            textNodeName:          "#_text"
-        });
-        //console.log(JSON.stringify(result,null,4));
-        expect(result).toEqual(expected);
-    });
+            attributeNamePrefix: "@",
+            textNodeName: "#_text",
+            arrayMode: true
+          });
+          expect(result).toEqual(expected);
+        }); */
 
-    /* it("should parse nodes as arrays", function () {
-      const fs = require("fs");
-      const path = require("path");
-      const fileNamePath = path.join(__dirname, "assets/sample.xml");
-      const xmlData = fs.readFileSync(fileNamePath).toString();
-
-      const expected = {
-        "any_name": [{
-          "@attr": ["https://example.com/somepath"],
-          "person": [{
-            "@id": ["101"],
-            "phone": [122233344550, 122233344551],
-            "name": ["Jack"],
-            "age": [33],
-            "emptyNode": [""],
-            "booleanNode": [false, true],
-            "selfclosing": [
-              "",
-              {
-                "@with": "value"
-              }
-            ],
-            "married": [{
-              "@firstTime": "No",
-              "@attr": "val 2",
-              "#_text": "Yes"
-            }],
-            "birthday": ["Wed, 28 Mar 1979 12:13:14 +0300"],
-            "address": [{
-              "city": ["New York"],
-              "street": ["Park Ave"],
-              "buildingNo": [1],
-              "flatNo": [1]
-            }, {
-              "city": ["Boston"],
-              "street": ["Centre St"],
-              "buildingNo": [33],
-              "flatNo": [24]
-            }]
-          }, {
-            "@id": ["102"],
-            "phone": [122233344553, 122233344554],
-            "name": ["Boris"],
-            "age": [34],
-            "married": [{
-                "@firstTime": "Yes",
-                "#_text": "Yes"
-            }],
-            "birthday": ["Mon, 31 Aug 1970 02:03:04 +0300"],
-            "address": [{
-                "city": ["Moscow"],
-                "street": ["Kahovka"],
-                "buildingNo": [1],
-                "flatNo": [2]
-            }, {
-                "city": ["Tula"],
-                "street": ["Lenina"],
-                "buildingNo": [3],
-                "flatNo": [78]
-            }]
-          }]
-        }]
-      };
-
-      const result = parser.parse(xmlData, {
-        ignoreAttributes: false,
-        ignoreNonTextNodeAttr: false,
-        attributeNamePrefix: "@",
-        textNodeName: "#_text",
-        arrayMode: true
-      });
-      expect(result).toEqual(expected);
-    }); */
-
-    it("should skip namespace", function() {
-        const xmlData = `\
-<soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/" >
-    <soap-env:Header>
-        <cor:applicationID>dashboardweb</cor:applicationID>
-        <cor:providerID>abc</cor:providerID>
-    </soap-env:Header>
-    <soap-env:Body>
-        <man:getOffers>
-            <man:customerId>
-                <cor:msisdn>123456789</cor:msisdn>
-            </man:customerId>
-        </man:getOffers>
-    </soap-env:Body>
-</soap-env:Envelope>`;
-        const expected = {
-            "Envelope": {
-                "Header": {
-                    "applicationID": "dashboardweb",
-                    "providerID":    "abc"
-                },
-                "Body":   {
-                    "getOffers": {
-                        "customerId": {
-                            "msisdn": 123456789
+        it("should skip namespace", function () {
+            const xmlData = `\
+    <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/" >
+        <soap-env:Header>
+            <cor:applicationID>dashboardweb</cor:applicationID>
+            <cor:providerID>abc</cor:providerID>
+        </soap-env:Header>
+        <soap-env:Body>
+            <man:getOffers>
+                <man:customerId>
+                    <cor:msisdn>123456789</cor:msisdn>
+                </man:customerId>
+            </man:getOffers>
+        </soap-env:Body>
+    </soap-env:Envelope>`;
+            const expected = {
+                "Envelope": {
+                    "Header": {
+                        "applicationID": "dashboardweb",
+                        "providerID": "abc"
+                    },
+                    "Body": {
+                        "getOffers": {
+                            "customerId": {
+                                "msisdn": 123456789
+                            }
                         }
                     }
                 }
-            }
-        };
+            };
 
-        const result = parser.parse(xmlData, {ignoreNameSpace: true});
-        expect(result).toEqual(expected);
-    });
-
-    it("should not trim tag value if not allowed ", function() {
-        const xmlData = "<rootNode>       123        </rootNode>";
-        const expected = {
-            "rootNode": "       123        "
-        };
-        const result = parser.parse(xmlData, {
-            parseNodeValue: false,
-            trimValues:     false
+            const result = parser.parse(xmlData, { ignoreNameSpace: true });
+            expect(result).toEqual(expected);
         });
-        //console.log(JSON.stringify(result,null,4));
-        expect(result).toEqual(expected);
-    });
 
-    it("should not trim tag value but not parse if not allowed ", function() {
-        const xmlData = "<rootNode>       123        </rootNode>";
-        const expected = {
-            "rootNode": "123"
-        };
-        const result = parser.parse(xmlData, {
-            parseNodeValue: false
+        it("should not trim tag value if not allowed ", function () {
+            const xmlData = "<rootNode>       123        </rootNode>";
+            const expected = {
+                "rootNode": "       123        "
+            };
+            const result = parser.parse(xmlData, {
+                parseNodeValue: false,
+                trimValues: false
+            });
+            //console.log(JSON.stringify(result,null,4));
+            expect(result).toEqual(expected);
         });
-        //console.log(JSON.stringify(result,null,4));
-        expect(result).toEqual(expected);
-    });
 
-    it("should not decode HTML entities by default", function() {
-        const xmlData = "<rootNode>       foo&ampbar&apos;        </rootNode>";
-        const expected = {
-            "rootNode": "foo&ampbar&apos;"
-        };
-        const result = parser.parse(xmlData, {
-            parseNodeValue: false
+        it("should not trim tag value but not parse if not allowed ", function () {
+            const xmlData = "<rootNode>       123        </rootNode>";
+            const expected = {
+                "rootNode": "123"
+            };
+            const result = parser.parse(xmlData, {
+                parseNodeValue: false
+            });
+            //console.log(JSON.stringify(result,null,4));
+            expect(result).toEqual(expected);
         });
-        //console.log(JSON.stringify(result,null,4));
-        expect(result).toEqual(expected);
-    });
 
-    it("should parse XML with DOCTYPE", function() {
-        const xmlData = "<?xml version=\"1.0\" standalone=\"yes\" ?>" +
-                        "<!--open the DOCTYPE declaration -" +
-                        "  the open square bracket indicates an internal DTD-->" +
-                        "<!DOCTYPE foo [" +
-                        "<!--define the internal DTD-->" +
-                        "<!ELEMENT foo (#PCDATA)>" +
-                        "<!--close the DOCTYPE declaration-->" +
-                        "]>" +
-                        "<foo>Hello World.</foo>";
-
-        const expected = {
-            foo: "Hello World."
-        };
-        const result = parser.parse(xmlData, {
-            //parseNodeValue: false,
-            //trimValues: false
+        it("should not decode HTML entities by default", function () {
+            const xmlData = "<rootNode>       foo&ampbar&apos;        </rootNode>";
+            const expected = {
+                "rootNode": "foo&ampbar&apos;"
+            };
+            const result = parser.parse(xmlData, {
+                parseNodeValue: false
+            });
+            //console.log(JSON.stringify(result,null,4));
+            expect(result).toEqual(expected);
         });
-        //console.log(JSON.stringify(result,null,4));
-        expect(result).toEqual(expected);
-    });
 
-    //Issue #77
-    it("should parse node with space in closing node", function() {
-        const xmlData = "<?xml version='1.0'?>"
-        + "<any_name>"
-        + "    <person>"
-        + "        <name1>Jack 1</name1 >"
-        + "        <name2>Jack 2</name2>"
-        + "    </person>"
-        + "</any_name>";
+        it("should parse XML with DOCTYPE", function () {
+            const xmlData = "<?xml version=\"1.0\" standalone=\"yes\" ?>" +
+                "<!--open the DOCTYPE declaration -" +
+                "  the open square bracket indicates an internal DTD-->" +
+                "<!DOCTYPE foo [" +
+                "<!--define the internal DTD-->" +
+                "<!ELEMENT foo (#PCDATA)>" +
+                "<!--close the DOCTYPE declaration-->" +
+                "]>" +
+                "<foo>Hello World.</foo>";
 
-        const expected = {
-            "any_name": {
-                "person": {
-                    "name1": "Jack 1",
-                    "name2": "Jack 2"
+            const expected = {
+                foo: "Hello World."
+            };
+            const result = parser.parse(xmlData, {
+                //parseNodeValue: false,
+                //trimValues: false
+            });
+            //console.log(JSON.stringify(result,null,4));
+            expect(result).toEqual(expected);
+        });
+
+        //Issue #77
+        it("should parse node with space in closing node", function () {
+            const xmlData = "<?xml version='1.0'?>"
+                + "<any_name>"
+                + "    <person>"
+                + "        <name1>Jack 1</name1 >"
+                + "        <name2>Jack 2</name2>"
+                + "    </person>"
+                + "</any_name>";
+
+            const expected = {
+                "any_name": {
+                    "person": {
+                        "name1": "Jack 1",
+                        "name2": "Jack 2"
+                    }
                 }
-            }
-        };
-        const result = parser.parse(xmlData);
-        //console.log(JSON.stringify(result,null,4));
-        expect(result).toEqual(expected);
-    });
+            };
+            const result = parser.parse(xmlData);
+            //console.log(JSON.stringify(result,null,4));
+            expect(result).toEqual(expected);
+        });
 
-    it("should parse node with text before, after and between of subtags", function() {
-        const xmlData = "<?xml version='1.0'?>"
-        + "<tag>before"
-        + "    <subtag>subtag text</subtag>"
-        + "    middle"
-        + "    <self />"
-        + "    after self"
-        + "    <subtag2>subtag text</subtag2>"
-        + "    after"
-        + "</tag>";
+        it("should parse node with text before, after and between of subtags", function () {
+            const xmlData = "<?xml version='1.0'?>"
+                + "<tag>before"
+                + "    <subtag>subtag text</subtag>"
+                + "    middle"
+                + "    <self />"
+                + "    after self"
+                + "    <subtag2>subtag text</subtag2>"
+                + "    after"
+                + "</tag>";
 
-        const expected = {
-            "tag": {
-                "#text": "before        middle        after self        after",
-                "subtag": "subtag text",
-                "self": "",
-                "subtag2": "subtag text"
-            }
-        };
+            const expected = {
+                "tag": {
+                    "#text": "before        middle        after self        after",
+                    "subtag": "subtag text",
+                    "self": "",
+                    "subtag2": "subtag text"
+                }
+            };
 
-        var result = validator.validate(xmlData);
-        expect(result).toBe(true);
+            var result = validator.validate(xmlData);
+            expect(result).toBe(true);
 
-        result = parser.parse(xmlData,{trimValues:false});
-        //console.log(JSON.stringify(result,null,4));
-        expect(result).toEqual(expected);
-    });
+            result = parser.parse(xmlData, { trimValues: false });
+            //console.log(JSON.stringify(result,null,4));
+            expect(result).toEqual(expected);
+        });
 
-    it("should validate before parsing", function() {
-        const xmlData = "<?xml version='1.0'?>"
-        + "<tag>"
-        + "    <subtag2>subtag text</subtag2>"
-        + "</tag";
+        it("should validate before parsing", function () {
+            const xmlData = "<?xml version='1.0'?>"
+                + "<tag>"
+                + "    <subtag2>subtag text</subtag2>"
+                + "</tag";
 
         expect(() => {
             parser.parse(xmlData,{trimValues:true}, true);
         }).toThrowError(`Closing tag 'tag' doesn't have proper closing.`)
 
-    });
+        });
 
-    it("should validate with options before parsing", function() {
-        const xmlData = "<?xml version='1.0'?>"
-        + "<tag foo>"
-        + "    <subtag2>subtag text</subtag2>"
-        + "</tag>";
+        it("should validate with options before parsing", function () {
+            const xmlData = "<?xml version='1.0'?>"
+                + "<tag foo>"
+                + "    <subtag2>subtag text</subtag2>"
+                + "</tag>";
 
-        const expected = {
-            "tag": {
-                "subtag2": "subtag text"
-            }
-        };
+            const expected = {
+                "tag": {
+                    "subtag2": "subtag text"
+                }
+            };
 
-        let result = parser.parse(xmlData,{trimValues:true}, { allowBooleanAttributes: true });
-        //console.log(JSON.stringify(result,null,4));
-        expect(result).toEqual(expected);
-    });
+            let result = parser.parse(xmlData, { trimValues: true }, { allowBooleanAttributes: true });
+            //console.log(JSON.stringify(result,null,4));
+            expect(result).toEqual(expected);
+        });
 });

--- a/src/json2xml.js
+++ b/src/json2xml.js
@@ -12,10 +12,10 @@ const defaultOptions = {
   format: false,
   indentBy: '  ',
   supressEmptyNode: false,
-  tagValueProcessor: function(a) {
+  tagValueProcessor: function (a) {
     return a;
   },
-  attrValueProcessor: function(a) {
+  attrValueProcessor: function (a) {
     return a;
   },
 };
@@ -37,7 +37,7 @@ const props = [
 function Parser(options) {
   this.options = buildOptions(options, defaultOptions, props);
   if (this.options.ignoreAttributes || this.options.attrNodeName) {
-    this.isAttribute = function(/*a*/) {
+    this.isAttribute = function (/*a*/) {
       return false;
     };
   } else {
@@ -47,7 +47,7 @@ function Parser(options) {
   if (this.options.cdataTagName) {
     this.isCDATA = isCDATA;
   } else {
-    this.isCDATA = function(/*a*/) {
+    this.isCDATA = function (/*a*/) {
       return false;
     };
   }
@@ -59,7 +59,7 @@ function Parser(options) {
     this.tagEndChar = '>\n';
     this.newLine = '\n';
   } else {
-    this.indentate = function() {
+    this.indentate = function () {
       return '';
     };
     this.tagEndChar = '>';
@@ -78,11 +78,11 @@ function Parser(options) {
   this.buildObjectNode = buildObjectNode;
 }
 
-Parser.prototype.parse = function(jObj) {
+Parser.prototype.parse = function (jObj) {
   return this.j2x(jObj, 0).val;
 };
 
-Parser.prototype.j2x = function(jObj, level) {
+Parser.prototype.j2x = function (jObj, level) {
   let attrStr = '';
   let val = '';
   const keys = Object.keys(jObj);
@@ -158,7 +158,7 @@ Parser.prototype.j2x = function(jObj, level) {
       }
     }
   }
-  return {attrStr: attrStr, val: val};
+  return { attrStr: attrStr, val: val };
 };
 
 function replaceCDATAstr(str, cdata) {
@@ -183,9 +183,9 @@ function replaceCDATAarr(str, cdata) {
 }
 
 function buildObjectNode(val, key, attrStr, level) {
-  // empty tag is used to specify an array of ordered tags, 
+  // #ordered is used to specify an array of ordered tags, 
   // only when the preserveOrder option is set.
-  if (key === "") {
+  if (key === "#ordered") {
     return val
   }
 

--- a/src/json2xml.js
+++ b/src/json2xml.js
@@ -183,6 +183,12 @@ function replaceCDATAarr(str, cdata) {
 }
 
 function buildObjectNode(val, key, attrStr, level) {
+  // empty tag is used to specify an array of ordered tags, 
+  // only when the preserveOrder option is set.
+  if (key === "") {
+    return val
+  }
+
   if (attrStr && !val.includes('<')) {
     return (
       this.indentate(level) +

--- a/src/node2json.js
+++ b/src/node2json.js
@@ -24,6 +24,20 @@ const convertToJson = function(node, options) {
   util.merge(jObj, node.attrsMap, options.arrayMode);
 
   const keys = Object.keys(node.child);
+
+  if (keys.length > 1 && (options.preserveOrder === true ||
+    (options.preserveOrder === "text" && keys.includes(options.textNodeName)))) {
+    const jArray = new Array(node.children)
+
+    for (let key of keys) {
+      for (var child of node.child[key]) {
+        jArray[child.indexInParent] = { [key]: convertToJson(child, options) };
+      }
+    }
+
+    return { "": jArray }
+  }
+
   for (let index = 0; index < keys.length; index++) {
     var tagname = keys[index];
     if (node.child[tagname] && node.child[tagname].length > 1) {

--- a/src/node2json.js
+++ b/src/node2json.js
@@ -2,7 +2,7 @@
 
 const util = require('./util');
 
-const convertToJson = function(node, options) {
+const convertToJson = function (node, options) {
   const jObj = {};
 
   //when no child node or attr is present
@@ -12,9 +12,9 @@ const convertToJson = function(node, options) {
     //otherwise create a textnode if node has some text
     if (util.isExist(node.val)) {
       if (!(typeof node.val === 'string' && (node.val === '' || node.val === options.cdataPositionChar))) {
-        if(options.arrayMode === "strict"){
-          jObj[options.textNodeName] = [ node.val ];
-        }else{
+        if (options.arrayMode === "strict") {
+          jObj[options.textNodeName] = [node.val];
+        } else {
           jObj[options.textNodeName] = node.val;
         }
       }
@@ -35,7 +35,9 @@ const convertToJson = function(node, options) {
       }
     }
 
-    return { "": jArray }
+    const result = { "#ordered": jArray }
+    util.merge(result, node.attrsMap, options.arrayMode)
+    return result
   }
 
   for (let index = 0; index < keys.length; index++) {
@@ -46,15 +48,15 @@ const convertToJson = function(node, options) {
         jObj[tagname].push(convertToJson(node.child[tagname][tag], options));
       }
     } else {
-      if(options.arrayMode === true){
+      if (options.arrayMode === true) {
         const result = convertToJson(node.child[tagname][0], options)
-        if(typeof result === 'object')
-          jObj[tagname] = [ result ];
+        if (typeof result === 'object')
+          jObj[tagname] = [result];
         else
           jObj[tagname] = result;
-      }else if(options.arrayMode === "strict"){
-        jObj[tagname] = [convertToJson(node.child[tagname][0], options) ];
-      }else{
+      } else if (options.arrayMode === "strict") {
+        jObj[tagname] = [convertToJson(node.child[tagname][0], options)];
+      } else {
         jObj[tagname] = convertToJson(node.child[tagname][0], options);
       }
     }

--- a/src/parser.d.ts
+++ b/src/parser.d.ts
@@ -15,6 +15,7 @@ type X2jOptions = {
   tagValueProcessor: (tagValue: string, tagName: string) => string;
   attrValueProcessor: (attrValue: string, attrName: string) => string;
   stopNodes: string[];
+  preserveOrder: boolean | 'text'
 };
 type X2jOptionsOptional = Partial<X2jOptions>;
 type validationOptions = {

--- a/src/xmlNode.js
+++ b/src/xmlNode.js
@@ -1,12 +1,14 @@
 'use strict';
 
 module.exports = function(tagname, parent, val) {
+  this.children = 0;
   this.tagname = tagname;
   this.parent = parent;
   this.child = {}; //child tags
   this.attrsMap = {}; //attributes map
   this.val = val; //text only
   this.addChild = function(child) {
+    child.indexInParent = this.children++
     if (Array.isArray(this.child[child.tagname])) {
       //already presents
       this.child[child.tagname].push(child);

--- a/src/xmlstr2xmlnode.js
+++ b/src/xmlstr2xmlnode.js
@@ -72,7 +72,7 @@ const nodeHasExtraText = (currentNode, textAfterNode) => {
 }
 
 const storeTextOrTextNode = (currentNode, options, tag) => {
-  if (!nodeHasExtraText(currentNode, tag[14])) {
+  if (!nodeHasExtraText(currentNode, tag[12])) {
     return
   }
   


### PR DESCRIPTION
# Purpose / Goal
<!-- Please specify here what you're planning to achieve by this pull request and how it can help in regard of this work-space. -->
This PR adds an option that preserves the order of tags as specified in #197. It is not meant as a finished update (although it works in the tests), but to continue the discussion that was started by @amitguptagwl. 

I look forward to seeing what you think of the change.



<!-- If it is a bug fix, please mention the issue number. If there is no issue has been raised but the PR directly then it should follow the template given to raise the issue. Like input, expected output, actual output etc. -->


# Type
Please mention the type of PR
<!-- choose one by changing [ ] to [x] -->
* [ ]Bug Fix
* [ ]Refactoring / Technology upgrade
* [x]New Feature

**Note** : Please ensure that you've read contribution [guidelines](https://github.com/NaturalIntelligence/fast-xml-parser/blob/master/docs/CONTRIBUTING.md) before raising this PR.

[Bookmark](https://github.com/NaturalIntelligence/fast-xml-parser/stargazers) this repository for further updates.
