### PR TITLE
Fix issue where invalid xml could be generated...

### DIFF
--- a/spec/j2x_spec.js
+++ b/spec/j2x_spec.js
@@ -202,6 +202,17 @@ describe("XMLParser", function() {
         expect(result).toEqual(expected);
     });
 
+    it("should add root node to xml if there is none", function() {
+        const jObj = {
+            a: { "foo": "bar" },
+            b: { "foo": "bar" }
+        };
+        const parser = new Parser();
+        const result = parser.parse(jObj);
+        const expected = `<root><a><foo>bar</foo></a><b><foo>bar</foo></b></root>`;
+        expect(result).toEqual(expected);
+    });
+
     it("should parse to XML with multiple cdata but textnode is not present", function() {
         const jObj = {
             a: {

--- a/src/json2xml.js
+++ b/src/json2xml.js
@@ -84,7 +84,7 @@ function Parser(options) {
 Parser.prototype.parse = function(jObj) {
   let val = this.j2x(jObj, 0).val;
   if (this.closeRoot) {
-    val += `</${this.rootTagName}>\n`;
+    val += `</${this.rootTagName}>${this.newLine}`;
   }
   return val;
 };
@@ -95,7 +95,7 @@ Parser.prototype.j2x = function(jObj, level) {
   const keys = Object.keys(jObj);
   const len = keys.length;
   if (len > 1 && level === 0) {
-    val += `<${this.rootTagName}>\n`;
+    val += `<${this.rootTagName}>${this.newLine}`;
     this.closeRoot = true;
     level = 1;
   }

--- a/src/json2xml.js
+++ b/src/json2xml.js
@@ -76,10 +76,17 @@ function Parser(options) {
 
   this.buildTextValNode = buildTextValNode;
   this.buildObjectNode = buildObjectNode;
+
+  this.closeRoot = false;
+  this.rootTagName = 'root';
 }
 
 Parser.prototype.parse = function(jObj) {
-  return this.j2x(jObj, 0).val;
+  let val = this.j2x(jObj, 0).val;
+  if (this.closeRoot) {
+    val += `</${this.rootTagName}>\n`;
+  }
+  return val;
 };
 
 Parser.prototype.j2x = function(jObj, level) {
@@ -87,6 +94,11 @@ Parser.prototype.j2x = function(jObj, level) {
   let val = '';
   const keys = Object.keys(jObj);
   const len = keys.length;
+  if (len > 1 && level === 0) {
+    val += `<${this.rootTagName}>\n`;
+    this.closeRoot = true;
+    level = 1;
+  }
   for (let i = 0; i < len; i++) {
     const key = keys[i];
     if (typeof jObj[key] === 'undefined') {


### PR DESCRIPTION
Fix issue where invalid xml could be generated from JSON without a root note.

# Purpose / Goal
This patch adds a `<root>` node to the output xml if the input JSON has no root nodes.

# Type
* [x]Bug Fix

