### PR TITLE
feat: add supressEmptyNodeWithoutAttributes option

### DIFF
--- a/spec/j2x_spec.js
+++ b/spec/j2x_spec.js
@@ -309,6 +309,27 @@ describe("XMLParser", function() {
         expect(result).toEqual(expected);
     });
 
+    it("should not supress empty node without attributes to self closing node when parsing to XML", function() {
+        const jObj = {
+            name: '',
+            address: ''
+        };
+        const parser = new Parser({
+                                      cdataTagName:     "__cdata",
+                                      attributeNamePrefix: "",
+                                      attrNodeName:     "@",
+                                      encodeHTMLchar:   true,
+                                      supressEmptyNode: true,
+                                      supressEmptyNodeWithoutAttributes: false,
+                                      tagValueProcessor: a=> { a= ''+ a; return he.encode(a, { useNamedReferences: true}) },
+                                      attrValueProcessor: a=> he.encode(a, {isAttributeValue: true, useNamedReferences: true})
+                                  });
+        const result = parser.parse(jObj);
+        //console.log(result);
+        const expected = `<name></name><address></address>`;
+        expect(result).toEqual(expected);
+    });
+
     it("should format when parsing to XML", function() {
         const jObj = {
             a: {

--- a/src/json2xml.js
+++ b/src/json2xml.js
@@ -12,6 +12,7 @@ const defaultOptions = {
   format: false,
   indentBy: '  ',
   supressEmptyNode: false,
+  supressEmptyNodeWithoutAttributes: true,
   tagValueProcessor: function(a) {
     return a;
   },
@@ -30,6 +31,7 @@ const props = [
   'format',
   'indentBy',
   'supressEmptyNode',
+  'supressEmptyNodeWithoutAttributes',
   'tagValueProcessor',
   'attrValueProcessor',
 ];
@@ -215,7 +217,7 @@ function buildObjectNode(val, key, attrStr, level) {
 }
 
 function buildEmptyObjNode(val, key, attrStr, level) {
-  if (val !== '') {
+  if (val !== '' || (!this.options.supressEmptyNodeWithoutAttributes && attrStr === '')) {
     return this.buildObjectNode(val, key, attrStr, level);
   } else {
     return this.indentate(level) + '<' + key + attrStr + '/' + this.tagEndChar;
@@ -238,7 +240,7 @@ function buildTextValNode(val, key, attrStr, level) {
 }
 
 function buildEmptyTextNode(val, key, attrStr, level) {
-  if (val !== '') {
+  if (val !== '' || (!this.options.supressEmptyNodeWithoutAttributes && attrStr === '')) {
     return this.buildTextValNode(val, key, attrStr, level);
   } else {
     return this.indentate(level) + '<' + key + attrStr + '/' + this.tagEndChar;

--- a/src/parser.d.ts
+++ b/src/parser.d.ts
@@ -31,6 +31,7 @@ type J2xOptions = {
   format: boolean;
   indentBy: string;
   supressEmptyNode: boolean;
+  supressEmptyNodeWithoutAttributes: boolean;
   tagValueProcessor: (tagValue: string) => string;
   attrValueProcessor: (attrValue: string) => string;
 };


### PR DESCRIPTION
# Purpose / Goal
I needed to convert a JSON attribute with an empty value to a not self closing XML tag:

**Input:**

```
{
  "name": "",
  "address": ""
}
```

**Expected output:**

```
<name></name><address></address>
```

**Actual output:**

```
<name/><address/>
```

# Benchmark results

Results of the `node benchmark\perfTest3.js` command, as requested at **CONTRIBUTING.md**:

**Before changes:**

Running Suite: XML Parser benchmark
validation : 22506.73362810279 requests/second
xml to json : 23379.649527832113 requests/second
xml to json + json string : 20339.19984773564 requests/second
xml to json string : 3201.794682753688 requests/second
xml2js  : 5631.943439669823 requests/second

**After changes:**

Running Suite: XML Parser benchmark
validation : 22660.97418380873 requests/second
xml to json : 22143.350711227682 requests/second
xml to json + json string : 19650.172211612786 requests/second
xml to json string : 3152.241109975055 requests/second
xml2js  : 5766.8773762699975 requests/second

# Type
Please mention the type of PR
<!-- choose one by changing [ ] to [x] -->
* [ ]Bug Fix
* [ ]Refactoring / Technology upgrade
* [X]New Feature
