### PR TITLE
Handle numbers ending in .0, .00, ...

### DIFF
--- a/spec/xmlParser_spec.js
+++ b/spec/xmlParser_spec.js
@@ -54,6 +54,63 @@ describe("XMLParser", function() {
         expect(result).toEqual(expected);
     });
 
+
+    it("should parse number ending in .0 for parseTrueNumberOnly:false", function () {
+        const xmlData = `<rootNode>
+        <floatTag0>0.0</floatTag0>
+        <floatTag1>1.0</floatTag1>
+        <floatTag2>2.0000</floatTag2>
+        <floatTag3 float="3.00"/>
+        </rootNode>`;
+        const expected = {
+            "rootNode": {
+                "floatTag0": 0,
+                "floatTag1": 1,
+                "floatTag2": 2,
+                "floatTag3": {
+                    "@_float": 3
+                }
+            }
+        };
+
+        const result = parser.parse(xmlData, {
+            ignoreAttributes: false,
+            parseAttributeValue: true,
+            parseTrueNumberOnly: false
+        });
+        //console.log(JSON.stringify(result,null,4));
+        expect(result).toEqual(expected);
+    });
+
+    it("should parse number ending in .0 for parseTrueNumberOnly:true", function () {
+        const xmlData = `<rootNode>
+        <floatTag0>0.0</floatTag0>
+        <floatTag1>1.0</floatTag1>
+        <floatTag2>2.0000</floatTag2>
+        <floatTag3 float="3.00"/>
+        </rootNode>`;
+        const expected = {
+            "rootNode": {
+                "floatTag0": 0,
+                "floatTag1": 1,
+                "floatTag2": 2,
+                "floatTag3": {
+                    "@_float": 3
+                }
+            }
+        };
+
+        const result = parser.parse(xmlData, {
+            ignoreAttributes: false,
+            parseAttributeValue: true,
+            parseTrueNumberOnly: true
+        });
+        //console.log(JSON.stringify(result,null,4));
+        expect(result).toEqual(expected);
+    });
+
+
+
     it("should not parse values to primitive type", function() {
         const xmlData = `<rootNode><tag>value</tag><boolean>true</boolean><intTag>045</intTag><floatTag>65.34</floatTag></rootNode>`;
         const expected = {

--- a/src/xmlstr2xmlnode.js
+++ b/src/xmlstr2xmlnode.js
@@ -189,7 +189,7 @@ function parseValue(val, shouldParse, parseTrueNumberOnly) {
         parsed = Number.parseInt(val, 16);
       } else if (val.indexOf('.') !== -1) {
         parsed = Number.parseFloat(val);
-        val = val.replace(/0+$/,"");
+        val = val.replace(/\.?0+$/, "");
       } else {
         parsed = Number.parseInt(val, 10);
       }


### PR DESCRIPTION
# Purpose / Goal
Fixes #234

The regular expression that trims off trailing 0:s off a decimal number (e.g. `12.340` → `12.34`) misses the case when there are only 0:s after the decimal point.
So we would expect `12.000` to become `12` but it actually becomes `12.`

This PR fixes this by adjusting the regular expression

Two commits:
- 546c66e: Adds test that proves that the current code produces invalid output, i.e tests fails
- d42ba03: Is the actual bugfix. The tests added in 546c66e runs now successfully

I've ran perfTest3 a few times and couldn't really notice any difference. Sometimes it's slower, most of the times it's faster. So I guess it doesn't affect performance.


# Type
* [x] Bug Fix
* [ ] Refactoring / Technology upgrade
* [ ] New Feature


