### PR TITLE
add `needToStop` callback to decide whether to parse a node into a string

### DIFF
--- a/spec/needToStop_spec.js
+++ b/spec/needToStop_spec.js
@@ -1,0 +1,103 @@
+"use strict";
+
+const parser = require("../src/parser");
+
+describe("XMLParser", function() {
+    it("stop by tag name", () => {
+        const xml = `<content>
+        <html><p><a href="hello.world">hello world</a></p></html>
+        <obj><title>hello world</title><link>hello.world</link></obj>
+        </content>`;
+
+        const result = parser.parse(xml, {
+            needToStop: tag => tag === 'html',
+        });
+
+        expect(result).toEqual({
+            content: {
+                html: '<p><a href="hello.world">hello world</a></p>',
+                obj: {
+                    title: 'hello world',
+                    link: 'hello.world'
+                }
+            }
+        });
+    });
+
+    it("stop by attr", () => {
+        const xml = `<content>
+        <html><p><a href="hello.world">hello world</a></p></html>
+        <text type="html"><p><a href="hello.world">hello world</a></p></text>
+        <text isHTML><p><a href="https://php.net/">PHP is the best programming language</a></p></text>
+        <obj><title>hello world</title><link>hello.world</link></obj>
+        </content>`;
+
+        const result = parser.parse(xml, {
+            attributeNamePrefix: "",
+            attrNodeName: "__attr",
+            textNodeName: "__text",
+            allowBooleanAttributes: true,
+            ignoreAttributes: false,
+            needToStop: (tag, attr) => tag === "html" || attr.isHTML || attr.type === "html",
+        });
+
+        expect(result).toEqual({
+            content: {
+                html: '<p><a href="hello.world">hello world</a></p>',
+                text: [
+                    {
+                        __text: '<p><a href="hello.world">hello world</a></p>',
+                        __attr: {type: 'html'}
+                    },
+                    {
+                        __text: '<p><a href="https://php.net/">PHP is the best programming language</a></p>',
+                        __attr: {isHTML: true}
+                    }
+                ],
+                obj: {
+                    title: 'hello world',
+                    link: 'hello.world'
+                }
+            }
+        });
+    });
+
+    it("compatible with stopNodes", () => {
+        const xml = `<content>
+        <html><p><a href="hello.world">hello world</a></p></html>
+        <text type="html"><p><a href="hello.world">hello world</a></p></text>
+        <text isHTML><p><a href="https://php.net/">PHP is the best programming language</a></p></text>
+        <obj><title>hello world</title><link>hello.world</link></obj>
+        </content>`;
+
+        const result = parser.parse(xml, {
+            attributeNamePrefix: "",
+            attrNodeName: "__attr",
+            textNodeName: "__text",
+            allowBooleanAttributes: true,
+            ignoreAttributes: false,
+            stopNodes: ["html"],
+            needToStop: (tag, attr) => attr.isHTML || attr.type === "html",
+        });
+
+        expect(result).toEqual({
+            content: {
+                html: '<p><a href="hello.world">hello world</a></p>',
+                text: [
+                    {
+                        __text: '<p><a href="hello.world">hello world</a></p>',
+                        __attr: {type: 'html'}
+                    },
+                    {
+                        __text: '<p><a href="https://php.net/">PHP is the best programming language</a></p>',
+                        __attr: {isHTML: true}
+                    }
+                ],
+                obj: {
+                    title: 'hello world',
+                    link: 'hello.world'
+                }
+            }
+        });
+    });
+})

--- a/spec/stopOn_spec.js
+++ b/spec/stopOn_spec.js
@@ -10,7 +10,7 @@ describe("XMLParser", function() {
         </content>`;
 
         const result = parser.parse(xml, {
-            needToStop: tag => tag === 'html',
+            stopOn: tag => tag === 'html',
         });
 
         expect(result).toEqual({
@@ -38,7 +38,7 @@ describe("XMLParser", function() {
             textNodeName: "__text",
             allowBooleanAttributes: true,
             ignoreAttributes: false,
-            needToStop: (tag, attr) => tag === "html" || attr.isHTML || attr.type === "html",
+            stopOn: (tag, attr) => tag === "html" || attr.isHTML || attr.type === "html",
         });
 
         expect(result).toEqual({
@@ -77,7 +77,7 @@ describe("XMLParser", function() {
             allowBooleanAttributes: true,
             ignoreAttributes: false,
             stopNodes: ["html"],
-            needToStop: (tag, attr) => attr.isHTML || attr.type === "html",
+            stopOn: (tag, attr) => attr.isHTML || attr.type === "html",
         });
 
         expect(result).toEqual({

--- a/src/parser.d.ts
+++ b/src/parser.d.ts
@@ -15,7 +15,7 @@ type X2jOptions = {
   tagValueProcessor: (tagValue: string, tagName: string) => string;
   attrValueProcessor: (attrValue: string, attrName: string) => string;
   stopNodes: string[];
-  needToStop: (tagName: string, attr: {[key: string]: string | number | boolean}) => boolean;
+  stopOn: (tagName: string, attr: {[key: string]: string | number | boolean}) => boolean;
 };
 type X2jOptionsOptional = Partial<X2jOptions>;
 type validationOptions = {

--- a/src/parser.d.ts
+++ b/src/parser.d.ts
@@ -15,6 +15,7 @@ type X2jOptions = {
   tagValueProcessor: (tagValue: string, tagName: string) => string;
   attrValueProcessor: (attrValue: string, attrName: string) => string;
   stopNodes: string[];
+  needToStop: (tagName: string, attr: {[key: string]: string | number | boolean}) => boolean;
 };
 type X2jOptionsOptional = Partial<X2jOptions>;
 type validationOptions = {

--- a/src/xmlstr2xmlnode.js
+++ b/src/xmlstr2xmlnode.js
@@ -39,7 +39,7 @@ const defaultOptions = {
     return a;
   },
   stopNodes: [],
-  needToStop: (tagName, attr) => false,
+  stopOn: (tagName, attr) => false,
   //decodeStrict: false,
 };
 
@@ -62,7 +62,7 @@ const props = [
   'attrValueProcessor',
   'parseTrueNumberOnly',
   'stopNodes',
-  'needToStop',
+  'stopOn',
 ];
 exports.props = props;
 
@@ -340,7 +340,7 @@ function needToStop(options, node) {
   if (attr === undefined) {
     attr = {};
   }
-  if (options.needToStop(node.tagname, attr)) {
+  if (options.stopOn(node.tagname, attr)) {
     return true;
   }
   return false;


### PR DESCRIPTION
# Purpose / Goal
<!-- Please specify here what you're planning to achieve by this pull request and how it can help in regard of this work-space. -->

I want to parse the XML in RSS format. If a node has the attribute `type="html"`, such as:

```xml
<content type="html">
  <p></p>
  <p><a href="https://code.visualstudio.com/blogs/2020/05/14/vscode-build-2020">Read the full article</a></p>
</content>
```

we should parse it into a string. However, `stopNodes` option can only determine whether to parse nodes into strings by tag name. So I add the option `needToStop`, which is a callback function, it will be called back and pass in the tag name and attributes, the node will be parsed into a string as long as the the function returns `true`.

<!-- If it is a bug fix, please mention the issue number. If there is no issue has been raised but the PR directly then it should follow the template given to raise the issue. Like input, expected output, actual output etc. -->


# Type
Please mention the type of PR
<!-- choose one by changing [ ] to [x] -->
* [ ]Bug Fix
* [ ]Refactoring / Technology upgrade
* [x]New Feature

**Note** : Please ensure that you've read contribution [guidelines](https://github.com/NaturalIntelligence/fast-xml-parser/blob/master/docs/CONTRIBUTING.md) before raising this PR. If your PR is in progress, please prepend `[WIP]` in PR title. Your PR will be reviewed when `[WIP]` will be removed from the PR title.

[Bookmark](https://github.com/NaturalIntelligence/fast-xml-parser/stargazers) this repository for further updates.
