### PR TITLE
Support IE 11 works on TypeScript when used by npm

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -44,12 +44,12 @@ function print(xmlNode, indentation){
     if(xmlNode.child){
       console.log(indentation + "\"child\": {")
       const indentation2 = indentation + indentation;
-      Object.keys(xmlNode.child).forEach( key =>{
+      Object.keys(xmlNode.child).forEach( function(key) {
         const node = xmlNode.child[key];
 
         if(Array.isArray(node)){
           console.log(indentation +  "\""+key+"\" :[")
-          node.forEach( (item,index) => {
+          node.forEach( function(item,index) {
             //console.log(indentation + " \""+index+"\" : [")
             print(item, indentation2);
           })


### PR DESCRIPTION
# Purpose / Goal
We can make IE 11 still works when use npm package. Example a block code on TypeScript:

```typescript
import { J2xOptions, j2xParser } from 'fast-xml-parser';

export function parseObjToXml(obj: any): string {
    const defaultOptions: J2xOptions = {
      attributeNamePrefix: '@',
      attrNodeName: false,
      textNodeName: '#text',
      ignoreAttributes: false,
      cdataTagName: false,
      cdataPositionChar: '\\c',
      format: true,
      indentBy: '  ',
      supressEmptyNode: false
    };
    const inMes = '<?xml version="1.0" encoding="UTF-8"?>\n';
    return inMes + new j2xParser(defaultOptions).parse(obj);
}
```

# Type
Please mention the type of PR
* [ ] Bug Fix
* [x] Refactoring
* [ ] New Feature
