### PR TITLE
fix(parse): fix parsing of multiline tag data when xml with no whitespaces between tags

### DIFF
--- a/spec/cdata_spec.js
+++ b/spec/cdata_spec.js
@@ -4,6 +4,25 @@ const parser = require("../src/parser");
 const validator = require("../src/validator");
 
 describe("XMLParser", function() {
+    it("should parse multiline tag value when tags without spaces", function() {
+        const xmlData = `<?xml version='1.0'?><root><person>lastname
+firstname
+patronymic</person></root>`;
+        let result = parser.parse(xmlData, {
+            ignoreAttributes: false
+        });
+
+        const expected = {
+            "root": {
+                "person": "lastname\nfirstname\npatronymic"
+            }
+        };
+
+        expect(result).toEqual(expected);
+
+        result = validator.validate(xmlData);
+        expect(result).toBe(true);
+    });
     it("should parse tag having CDATA", function() {
         const xmlData = `<?xml version='1.0'?>
 <any_name>
@@ -32,7 +51,6 @@ describe("XMLParser", function() {
                 }
             }
         };
-
         let result = parser.parse(xmlData, {
             ignoreAttributes: false
         });

--- a/spec/data_spec.js
+++ b/spec/data_spec.js
@@ -101,7 +101,7 @@ describe("XMLParser", function() {
                 },
                 "a:b": 2,
                 "a-b:b-a": 2,
-                "a:c": "test&amp;\r\nтест&lt;\r\ntest",
+                "a:c": "test&amp;\nтест&lt;\ntest",
                 "a:el": "<a>&lt;<a/>&lt;b&gt;2</b>]]]]>&amp;a",
                 "c:string": {
                     "#text": "&#x441;&#x442;&#x440;&#x430;&#x445;&#x43e;&#x432;&#x430;&#x43d;&#x438;&#x44f;    » &#x43e;&#x442; &#x441;&#x443;&#x43c;&#x43c;&#x44b;     &#x435;&#x433;&#x43e; &#x430;&#x43a;&#x442;&#x438;&#x432;&#x43e;&#x432;",

--- a/src/xmlstr2xmlnode.js
+++ b/src/xmlstr2xmlnode.js
@@ -168,7 +168,7 @@ function buildAttributesMap(attrStr, options) {
 }
 
 const getTraversalObj = function(xmlData, options) {
-  xmlData = xmlData.replace(/(\r\n)|\n/, " ");
+  xmlData = xmlData.replace(/\r?\n/g, "\n");
   options = buildOptions(options, defaultOptions, props);
   const xmlObj = new xmlNode('!xml');
   let currentNode = xmlObj;

--- a/src/xmlstr2xmlnode.js
+++ b/src/xmlstr2xmlnode.js
@@ -168,7 +168,7 @@ function buildAttributesMap(attrStr, options) {
 }
 
 const getTraversalObj = function(xmlData, options) {
-  xmlData = xmlData.replace(/\r?\n/g, "\n");
+  xmlData = xmlData.replace(/\r\n?/g, "\n");
   options = buildOptions(options, defaultOptions, props);
   const xmlObj = new xmlNode('!xml');
   let currentNode = xmlObj;


### PR DESCRIPTION
…

# Purpose / Goal
<!-- Please specify here what you're planning to achieve by this pull request and how it can help in regard of this work-space. -->
```xml
<root><a>1
2
3</a></root>
```
previously parsed as 
```json
{"root":{"a":"1 2\n3"}}
```
instead of
```json
{"root":{"a":"1\n2\n3"}}
```

<!-- If it is a bug fix, please mention the issue number. If there is no issue has been raised but the PR directly then it should follow the template given to raise the issue. Like input, expected output, actual output etc. -->


# Type
Please mention the type of PR
<!-- choose one by changing [ ] to [x] -->
* [x]Bug Fix
* [ ]Refactoring / Technology upgrade
* [ ]New Feature

**Note** : Please ensure that you've read contribution [guidelines](https://github.com/NaturalIntelligence/fast-xml-parser/blob/master/docs/CONTRIBUTING.md) before raising this PR. If your PR is in progress, please prepend `[WIP]` in PR title. Your PR will be reviewed when `[WIP]` will be removed from the PR title.

[Bookmark](https://github.com/NaturalIntelligence/fast-xml-parser/stargazers) this repository for further updates.
