### PR TITLE
Add ignoreRootElement option

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Validator returns the following object in case of error;
 * **ignoreAttributes** : Ignore attributes to be parsed.
 * **ignoreNameSpace** : Remove namespace string from tag and attribute names.
 * **allowBooleanAttributes** : a tag can have attributes without any value
+* **ignoreRootElement** : Don't include the root element in the result object.
 * **parseNodeValue** : Parse the value of text node to float, integer, or boolean.
 * **parseAttributeValue** : Parse the value of an attribute to float, integer, or boolean.
 * **trimValues** : trim string values of an attribute or node

--- a/spec/xmlParser_spec.js
+++ b/spec/xmlParser_spec.js
@@ -825,4 +825,18 @@ describe("XMLParser", function() {
         //console.log(JSON.stringify(result,null,4));
         expect(result).toEqual(expected);
     });
+
+    it("should ignore root element", function() {
+        const xmlData = "<?xml version='1.0'?>"
+        + "<tag>"
+        + "    <subtag2>subtag text</subtag2>"
+        + "</tag>";
+
+        const expected = {
+            "subtag2": "subtag text"
+        };
+
+        let result = parser.parse(xmlData, { ignoreRootElement: true });
+        expect(result).toEqual(expected);
+    });
 });

--- a/src/parser.js
+++ b/src/parser.js
@@ -9,7 +9,7 @@ const validator = require('./validator');
 exports.parse = function(xmlData, options, validationOption) {
   if( validationOption){
     if(validationOption === true) validationOption = {}
-    
+
     const result = validator.validate(xmlData, validationOption);
     if (result !== true) {
       throw Error( result.err.msg)
@@ -18,7 +18,8 @@ exports.parse = function(xmlData, options, validationOption) {
   options = buildOptions(options, x2xmlnode.defaultOptions, x2xmlnode.props);
   const traversableObj = xmlToNodeobj.getTraversalObj(xmlData, options)
   //print(traversableObj, "  ");
-  return nodeToJson.convertToJson(traversableObj, options);
+  const json = nodeToJson.convertToJson(traversableObj, options);
+  return options.ignoreRootElement ? json[Object.keys(json)[0]] : json;
 };
 exports.convertTonimn = require('../src/nimndata').convert2nimn;
 exports.getTraversalObj = xmlToNodeobj.getTraversalObj;
@@ -53,11 +54,11 @@ function print(xmlNode, indentation){
             //console.log(indentation + " \""+index+"\" : [")
             print(item, indentation2);
           })
-          console.log(indentation + "],")  
+          console.log(indentation + "],")
         }else{
           console.log(indentation + " \""+key+"\" : {")
           print(node, indentation2);
-          console.log(indentation + "},")  
+          console.log(indentation + "},")
         }
       });
       console.log(indentation + "},")

--- a/src/xmlstr2xmlnode.js
+++ b/src/xmlstr2xmlnode.js
@@ -25,7 +25,7 @@ const defaultOptions = {
   ignoreAttributes: true,
   ignoreNameSpace: false,
   allowBooleanAttributes: false, //a tag can have attributes without any value
-  //ignoreRootElement : false,
+  ignoreRootElement: false,
   parseNodeValue: true,
   parseAttributeValue: false,
   arrayMode: false,
@@ -51,6 +51,7 @@ const props = [
   'ignoreAttributes',
   'ignoreNameSpace',
   'allowBooleanAttributes',
+  'ignoreRootElement',
   'parseNodeValue',
   'parseAttributeValue',
   'arrayMode',


### PR DESCRIPTION
This allows to flatten the result to actual contents of XML document.
Closes #282 

# Purpose / Goal

This additional option allows us to get a bit flattened structure of resulting object, eg.

```xml
<?xml version='1.0'?>
<tag>
  <subtag>subtag text</subtag>
</tag>
```

After parse is:
```js
{
  subtag: "subtag text"
}
```

intead of unnecessarily nested:

```js
{
  tag: {
    subtag: "subtag text"
  }
}
```

# Type
Please mention the type of PR
<!-- choose one by changing [ ] to [x] -->
* [ ]Bug Fix
* [ ]Refactoring / Technology upgrade
* [x]New Feature

# Benchmark results

## Before:

```
Running Suite: XML Parser benchmark
validation : 27967.469486403712 requests/second
xml to json : 22430.23111306954 requests/second
xml to json + json string : 21924.37282500639 requests/second
xml to json string : 3690.5505676223656 requests/second
xml2js  : 6878.66892887592 requests/second
```

## After:

```
Running Suite: XML Parser benchmark
validation : 28078.568637236047 requests/second
xml to json : 25290.970897866137 requests/second
xml to json + json string : 21246.264892084164 requests/second
xml to json string : 3717.473088434135 requests/second
xml2js  : 6817.922793520032 requests/second
```
