### PR TITLE
fix: remove `postinstall` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "bundle": "webpack && webpack --config webpack-prod.config.js",
     "coverage": "istanbul cover -x \"cli.js\" -x \"spec/*spec.js\" jasmine spec/*spec.js;",
     "coverage:check": "istanbul check-coverage --branch 90 --statement 90",
-    "postinstall": "node tasks/postinstall.js || exit 0",
     "prettier": "prettier --write src/**/*.js",
     "publish-please": "publish-please",
     "prepublishOnly": "publish-please guard"

--- a/tasks/postinstall.js
+++ b/tasks/postinstall.js
@@ -1,5 +1,0 @@
-#!/usr/bin/env node
-
-
-const msg = '\u001b[96m\u001b[1mLove fast-xml-parser? Check \u001b[32mhttps://amitkumargupta.work \u001b[96m\u001b[1mfor more projects and contribution.\u001b[0m\n';
-console.log(msg)


### PR DESCRIPTION
# Purpose / Goal
<!-- Please specify here what you're planning to achieve by this pull request and how it can help in regard of this work-space. -->

<!-- If it is a bug fix, please mention the issue number. If there is no issue has been raised but the PR directly then it should follow the template given to raise the issue. Like input, expected output, actual output etc. -->

`postinstall` scripts tend to be obnoxious when used for advertising, and there are [better methods available](https://docs.npmjs.com/cli/v6/commands/npm-fund). Usually if someone is interested in contributing, they'll seek out projects to contribute to, but `postinstall` scripts are shown on every build resulting in noisy logs that make it harder to debug failing builds.

The nature of `postinstall` means it can't be disabled without risking disabling an actual `postinstall` that is required for a particular package, and any form of check within the script (i.e for an env variable) won't prevent all the noise since the package managers always print the path to the scripts they're running before they run them.

Resolves #236


# Type
Please mention the type of PR
<!-- choose one by changing [ ] to [x] -->
* [ ]Bug Fix
* [x]Refactoring / Technology upgrade
* [ ]New Feature
