### PR TITLE
feat(arrayMode): support RegEx and function in arrayMode option

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Validator returns the following object in case of error;
 * **cdataTagName** : If specified, parser parse CDATA as nested tag instead of adding it's value to parent tag.
 * **cdataPositionChar** : It'll help to covert JSON back to XML without losing CDATA position.
 * **parseTrueNumberOnly**: if true then values like "+123", or "0123" will not be parsed as number.
-* **arrayMode** : When `false`, a tag with single occurrence is parsed as an object but as an array in case of multiple occurences. When `true`, a tag will be parsed as an array always excluding leaf nodes. When `strict`, all the tags will be parsed as array only.
+* **arrayMode** : When `false`, a tag with single occurrence is parsed as an object but as an array in case of multiple occurences. When `true`, a tag will be parsed as an array always excluding leaf nodes. When `strict`, all the tags will be parsed as array only. When instance of `RegEx`, only tags will be parsed as array that match the regex. When `function` a tag name is passed to the callback that can be checked.
 * **tagValueProcessor** : Process tag value during transformation. Like HTML decoding, word capitalization, etc. Applicable in case of string only.
 * **attrValueProcessor** : Process attribute value during transformation. Like HTML decoding, word capitalization, etc. Applicable in case of string only.
 * **stopNodes** : an array of tag names which are not required to be parsed. Instead their values are parsed as string.

--- a/spec/arrayMode_spec.js
+++ b/spec/arrayMode_spec.js
@@ -227,11 +227,86 @@ describe("XMLParser with arrayMode enabled", function () {
         expect(regExResult).toEqual(expected);
 
         const cbExResult = parser.parse(xmlData, {
-            arrayMode: function (tagname) {
-                return ['inventory', 'item'].includes(tagname)
+            arrayMode: function (tagName) {
+                return ['inventory', 'item'].includes(tagName)
             },
             ignoreAttributes: false,
         });
+        expect(cbExResult).toEqual(expected);
+    });
+
+    it("should parse all the tags as an array that match arrayMode callback with parent tag", function () {
+        const xmlData = `<report>
+        <store>
+            <region>US</region>
+            <inventory>
+                <item grade="A">
+                    <name>Banana</name>
+                    <count>200</count>
+                </item>
+                <item grade="B">
+                    <name>Apple</name>
+                    <count>100</count>
+                </item>
+            </inventory>
+        </store>
+        <store>
+            <region>EU</region>
+            <inventory>
+                <item>
+                    <name>Banana</name>
+                    <count>100</count>
+                </item>
+            </inventory>
+        </store>
+    </report>`;
+
+        const expected = {
+            "report":
+              {
+                  "store": [
+                      {
+                          "region": "US",
+                          "inventory":
+                            {
+                                "item": [
+                                    {
+                                        "@_grade": "A",
+                                        "name": "Banana",
+                                        "count": 200
+                                    },
+                                    {
+                                        "@_grade": "B",
+                                        "name": "Apple",
+                                        "count": 100
+                                    }
+                                ]
+                            }
+                      },
+                      {
+                          "region": "EU",
+                          "inventory":
+                            {
+                                "item": [
+                                    {
+                                        "name": "Banana",
+                                        "count": 100
+                                    }
+                                ]
+                            }
+                      }
+                  ]
+              }
+
+        };
+
+        const cbExResult = parser.parse(xmlData, {
+            arrayMode: function (tagName, parentTagName) {
+                return parentTagName === 'inventory';
+            },
+            ignoreAttributes: false,
+        });
+
         expect(cbExResult).toEqual(expected);
     });
 });

--- a/src/node2json.js
+++ b/src/node2json.js
@@ -5,19 +5,16 @@ const util = require('./util');
 const convertToJson = function(node, options) {
   const jObj = {};
 
-  //when no child node or attr is present
+  // when no child node or attr is present
   if ((!node.child || util.isEmptyObject(node.child)) && (!node.attrsMap || util.isEmptyObject(node.attrsMap))) {
     return util.isExist(node.val) ? node.val : '';
-  } else {
-    //otherwise create a textnode if node has some text
-    if (util.isExist(node.val)) {
-      if (!(typeof node.val === 'string' && (node.val === '' || node.val === options.cdataPositionChar))) {
-        if(options.arrayMode === "strict"){
-          jObj[options.textNodeName] = [ node.val ];
-        }else{
-          jObj[options.textNodeName] = node.val;
-        }
-      }
+  }
+
+  // otherwise create a textnode if node has some text
+  if (util.isExist(node.val)) {
+    if (!(typeof node.val === 'string' && (node.val === '' || node.val === options.cdataPositionChar))) {
+      const asArray = util.isTagnameInArrayMode(node.tagname, options.arrayMode)
+      jObj[options.textNodeName] = asArray ? [node.val] : node.val;
     }
   }
 
@@ -25,25 +22,18 @@ const convertToJson = function(node, options) {
 
   const keys = Object.keys(node.child);
   for (let index = 0; index < keys.length; index++) {
-    var tagname = keys[index];
+    const tagname = keys[index];
     if (node.child[tagname] && node.child[tagname].length > 1) {
       jObj[tagname] = [];
-      for (var tag in node.child[tagname]) {
-        if (node.child[tagname].hasOwnProperty(tag)){
-          jObj[tagname].push(convertToJson(node.child[tagname][tag], options));}
+      for (let tag in node.child[tagname]) {
+        if (node.child[tagname].hasOwnProperty(tag)) {
+          jObj[tagname].push(convertToJson(node.child[tagname][tag], options));
         }
-    } else {
-      if(options.arrayMode === true){
-        const result = convertToJson(node.child[tagname][0], options)
-        if(typeof result === 'object')
-          jObj[tagname] = [ result ];
-        else
-          jObj[tagname] = result;
-      }else if(options.arrayMode === "strict"){
-        jObj[tagname] = [convertToJson(node.child[tagname][0], options) ];
-      }else{
-        jObj[tagname] = convertToJson(node.child[tagname][0], options);
       }
+    } else {
+      const result = convertToJson(node.child[tagname][0], options);
+      const asArray = (options.arrayMode === true && typeof result === 'object') || util.isTagnameInArrayMode(tagname, options.arrayMode);
+      jObj[tagname] = asArray ? [result] : result;
     }
   }
 

--- a/src/node2json.js
+++ b/src/node2json.js
@@ -2,7 +2,7 @@
 
 const util = require('./util');
 
-const convertToJson = function(node, options) {
+const convertToJson = function(node, options, parentTagName) {
   const jObj = {};
 
   // when no child node or attr is present
@@ -11,29 +11,27 @@ const convertToJson = function(node, options) {
   }
 
   // otherwise create a textnode if node has some text
-  if (util.isExist(node.val)) {
-    if (!(typeof node.val === 'string' && (node.val === '' || node.val === options.cdataPositionChar))) {
-      const asArray = util.isTagnameInArrayMode(node.tagname, options.arrayMode)
-      jObj[options.textNodeName] = asArray ? [node.val] : node.val;
-    }
+  if (util.isExist(node.val) && !(typeof node.val === 'string' && (node.val === '' || node.val === options.cdataPositionChar))) {
+    const asArray = util.isTagNameInArrayMode(node.tagname, options.arrayMode, parentTagName)
+    jObj[options.textNodeName] = asArray ? [node.val] : node.val;
   }
 
   util.merge(jObj, node.attrsMap, options.arrayMode);
 
   const keys = Object.keys(node.child);
   for (let index = 0; index < keys.length; index++) {
-    const tagname = keys[index];
-    if (node.child[tagname] && node.child[tagname].length > 1) {
-      jObj[tagname] = [];
-      for (let tag in node.child[tagname]) {
-        if (node.child[tagname].hasOwnProperty(tag)) {
-          jObj[tagname].push(convertToJson(node.child[tagname][tag], options));
+    const tagName = keys[index];
+    if (node.child[tagName] && node.child[tagName].length > 1) {
+      jObj[tagName] = [];
+      for (let tag in node.child[tagName]) {
+        if (node.child[tagName].hasOwnProperty(tag)) {
+          jObj[tagName].push(convertToJson(node.child[tagName][tag], options, tagName));
         }
       }
     } else {
-      const result = convertToJson(node.child[tagname][0], options);
-      const asArray = (options.arrayMode === true && typeof result === 'object') || util.isTagnameInArrayMode(tagname, options.arrayMode);
-      jObj[tagname] = asArray ? [result] : result;
+      const result = convertToJson(node.child[tagName][0], options, tagName);
+      const asArray = (options.arrayMode === true && typeof result === 'object') || util.isTagNameInArrayMode(tagName, options.arrayMode, parentTagName);
+      jObj[tagName] = asArray ? [result] : result;
     }
   }
 

--- a/src/parser.d.ts
+++ b/src/parser.d.ts
@@ -7,7 +7,7 @@ type X2jOptions = {
   allowBooleanAttributes: boolean;
   parseNodeValue: boolean;
   parseAttributeValue: boolean;
-  arrayMode: boolean | 'strict' | RegExp | ((tagName: string) => boolean);
+  arrayMode: boolean | 'strict' | RegExp | ((tagName: string, parentTagName: string) => boolean);
   trimValues: boolean;
   cdataTagName: false | string;
   cdataPositionChar: string;

--- a/src/parser.d.ts
+++ b/src/parser.d.ts
@@ -7,7 +7,7 @@ type X2jOptions = {
   allowBooleanAttributes: boolean;
   parseNodeValue: boolean;
   parseAttributeValue: boolean;
-  arrayMode: boolean | 'strict';
+  arrayMode: boolean | 'strict' | RegExp | ((tagName: string) => boolean);
   trimValues: boolean;
   cdataTagName: false | string;
   cdataPositionChar: string;

--- a/src/util.js
+++ b/src/util.js
@@ -83,17 +83,20 @@ exports.buildOptions = function(options, defaultOptions, props) {
 };
 
 /**
- * Check if a tagname should be treated as array
+ * Check if a tag name should be treated as array
  *
- * @param tagname the node tagname
- * @param arrayMode
+ * @param tagName the node tagname
+ * @param arrayMode the array mode option
+ * @param parentTagName the parent tag name
  * @returns {boolean} true if node should be parsed as array
  */
-exports.isTagnameInArrayMode = function (tagname, arrayMode) {
-  if (arrayMode instanceof RegExp) {
-    return arrayMode.test(tagname)
+exports.isTagNameInArrayMode = function (tagName, arrayMode, parentTagName) {
+  if (arrayMode === false) {
+    return false;
+  } else if (arrayMode instanceof RegExp) {
+    return arrayMode.test(tagName);
   } else if (typeof arrayMode === 'function') {
-    return !!arrayMode(tagname)
+    return !!arrayMode(tagName, parentTagName);
   }
 
   return arrayMode === "strict";

--- a/src/util.js
+++ b/src/util.js
@@ -43,9 +43,9 @@ exports.merge = function(target, a, arrayMode) {
     const keys = Object.keys(a); // will return an array of own properties
     const len = keys.length; //don't make it inline
     for (let i = 0; i < len; i++) {
-      if(arrayMode === 'strict'){
+      if (arrayMode === 'strict') {
         target[keys[i]] = [ a[keys[i]] ];
-      }else{
+      } else {
         target[keys[i]] = a[keys[i]];
       }
     }
@@ -81,6 +81,23 @@ exports.buildOptions = function(options, defaultOptions, props) {
   }
   return newOptions;
 };
+
+/**
+ * Check if a tagname should be treated as array
+ *
+ * @param tagname the node tagname
+ * @param arrayMode
+ * @returns {boolean} true if node should be parsed as array
+ */
+exports.isTagnameInArrayMode = function (tagname, arrayMode) {
+  if (arrayMode instanceof RegExp) {
+    return arrayMode.test(tagname)
+  } else if (typeof arrayMode === 'function') {
+    return !!arrayMode(tagname)
+  }
+
+  return arrayMode === "strict";
+}
 
 exports.isName = isName;
 exports.getAllMatches = getAllMatches;


### PR DESCRIPTION
# Purpose / Goal
Enhance the `arrayMode` with RegEx/Callback to be able to control which Tags should be returned as an array.
This feature enables fine grained and correct XML parsing where it's known that some tags only return an array.

See [discussion](https://github.com/NaturalIntelligence/fast-xml-parser/issues/68)

# The problem
```json
{
  "items": [
      {"name": "item1"}
   ]
}
```
Will produce:
```xml
<?xml version="1.0"?>
<items>
  <name>item1</name>
</items>
```
That's fine, but if we want to parse it back to same JSON we can now use:
```js
var jsonObj = parser.convertToJson(tObj, {
  arrayMode: /items/
});
```
This will produce expected output.

Sometimes RegEx can be complicated, thefore a cb can be used:
```js
var jsonObj = parser.convertToJson(tObj, {
  arrayMode: function(tagname) { return tagname === 'items'}
});
```

Performace should only be decreased if this option is used.

# Type
Please mention the type of PR
* [ ]Bug Fix
* [ ]Refactoring / Technology upgrade
* [x ]New Feature

# Suite: XML Parser benchmark
validation : 27487.975686280235 requests/second
xml to json : 23590.962156918744 requests/second
xml to json + json string : 20555.733716481 requests/second
xml to json string : 3414.0281077820946 requests/second
xml2js  : 6776.869020960357 requests/second

[Bookmark](https://github.com/NaturalIntelligence/fast-xml-parser/stargazers) this repository for further updates.
