### PR TITLE
Fix namspaced tag parsing

### DIFF
--- a/spec/data_spec.js
+++ b/spec/data_spec.js
@@ -178,6 +178,25 @@ describe("XMLParser", function() {
         expect(result).toEqual(expected);
     });
 
+    it("should parse XML when namespaced ignored", function() {
+        const xmlData = `<a:b>c</a:b><a:d/><a:e atr="sasa" boolean>`;
+        const expected = {
+            "b" : "c",
+            "d" : "",
+            "e" : {
+                "@_atr": "sasa",
+                "@_boolean": true,
+            }
+        };
+
+        const result = parser.parse(xmlData, {
+            ignoreAttributes:       false,
+            allowBooleanAttributes: true,
+            ignoreNameSpace:        true,
+        });
+        expect(result).toEqual(expected);
+    });
+
     it("should parse XML with undefined as text", function() {
         const xmlData = `<tag><![CDATA[undefined]]><nested>undefined</nested></tag>`;
         const expected = {

--- a/src/xmlstr2xmlnode.js
+++ b/src/xmlstr2xmlnode.js
@@ -253,6 +253,7 @@ const getTraversalObj = function(xmlData, options) {
         const closeIndex = result.index;
         const separatorIndex = tagExp.indexOf(" ");
         let tagName = tagExp;
+        let shouldBuildAttributesMap = true;
         if(separatorIndex !== -1){
           tagName = tagExp.substr(0, separatorIndex).replace(/\s\s*$/, '');
           tagExp = tagExp.substr(separatorIndex + 1);
@@ -262,6 +263,7 @@ const getTraversalObj = function(xmlData, options) {
           const colonIndex = tagName.indexOf(":");
           if(colonIndex !== -1){
             tagName = tagName.substr(colonIndex+1);
+            shouldBuildAttributesMap = tagName !== result.data.substr(colonIndex + 1);
           }
         }
 
@@ -292,7 +294,7 @@ const getTraversalObj = function(xmlData, options) {
           if (options.stopNodes.length && options.stopNodes.includes(childNode.tagname)) {
             childNode.startIndex=closeIndex;
           }
-          if(tagName !== tagExp){
+          if(tagName !== tagExp && shouldBuildAttributesMap){
             childNode.attrsMap = buildAttributesMap(tagExp, options);
           }
           currentNode.addChild(childNode);


### PR DESCRIPTION
# Purpose / Goal
<!-- Please specify here what you're planning to achieve by this pull request and how it can help in regard of this work-space. -->

<!-- If it is a bug fix, please mention the issue number. If there is no issue has been raised but the PR directly then it should follow the template given to raise the issue. Like input, expected output, actual output etc. -->

This is a naive attempt at solving the following issue:

https://github.com/NaturalIntelligence/fast-xml-parser/issues/320

Please note that my experience with this repository is fairly low, so I might have missed something important.

# Type
Please mention the type of PR
<!-- choose one by changing [ ] to [x] -->
* [x] Bug Fix
* [ ] Refactoring / Technology upgrade
* [ ] New Feature

# Benchmark

## Before

```
Running Suite: XML Parser benchmark
validation : 29237.1202899018 requests/second
xml to json : 24875.297773092963 requests/second
xml to json + json string : 22191.624311589047 requests/second
xml to json string : 3994.622584408293 requests/second
xml2js  : 7993.719125817242 requests/second
```


## After

```
Running Suite: XML Parser benchmark
validation : 29701.63520998558 requests/second
xml to json : 26255.646131059493 requests/second
xml to json + json string : 22435.547703433473 requests/second
xml to json string : 3904.6532980072416 requests/second
xml2js  : 7286.735343585023 requests/second
```

NB: benchmarking requires `benchmark` and `xml2js` (dev) dependencies that are currently not referenced in `package.json`
