### PR TITLE
Fix Import of nimndata in parser

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -20,7 +20,7 @@ exports.parse = function(xmlData, options, validationOption) {
   //print(traversableObj, "  ");
   return nodeToJson.convertToJson(traversableObj, options);
 };
-exports.convertTonimn = require('../src/nimndata').convert2nimn;
+exports.convertTonimn = require('./nimndata').convert2nimn;
 exports.getTraversalObj = xmlToNodeobj.getTraversalObj;
 exports.convertToJson = nodeToJson.convertToJson;
 exports.convertToJsonString = require('./node2json_str').convertToJsonString;


### PR DESCRIPTION
# Purpose / Goal
On a fresh install off this package whenever I tried to use the parse I would run into a an error 

```
  Could not locate module ../src/nimndata mapped as:
    /Users/{my project...}/src/$1.
```

I notice that all the other imports in the `parse.js` file use `"./filename"` for imports. So i changed this to match. 

# Type
* [x] Bug Fix


[Bookmark](https://github.com/NaturalIntelligence/fast-xml-parser/stargazers) this repository for further updates.
