### PR TITLE
Updating licensing note per recent license change

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,4 +351,3 @@ Support this project by becoming a sponsor. Your logo will show up here with a l
 # License
 
 * MIT License
-* We may mention the logo/name/reference of the users without further permission required. However, you can request to remove it,if you're not the user of this library anymore. We'll do the necessary changes ASAP.

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
       "url": "https://github.com/Tatsh"
     }
   ],
-  "license": "MIT Modified",
+  "license": "MIT",
   "devDependencies": {
     "@babel/core": "^7.12.10",
     "@babel/plugin-transform-runtime": "^7.12.10",


### PR DESCRIPTION
Hi fast-xml-parser folk,

I noticed the license change back to MIT. I've updated the package.json and README to fit with that change; I hope that's okay.