### PR TITLE
[WIP] Forcing text node on a leaf regardless of having attributes

### DIFF
--- a/spec/xmlParser_spec.js
+++ b/spec/xmlParser_spec.js
@@ -397,6 +397,21 @@ describe("XMLParser", function() {
         expect(result).toEqual(expected);
     });
 
+
+    it("should enforce text node when flag supplied", function() {
+        const xmlData = `<tag.1 t1='1'>val1</tag.1><tag.2>val2</tag.2>`;
+        const expected = {
+            "tag.1": { "#text": 'val1', "@_t1": '1' },
+            "tag.2": { "#text": 'val2' },
+        };
+
+        const result = parser.parse(xmlData, {
+            ignoreAttributes: false,
+            forceTextNode: true,
+        });
+        expect(result).toEqual(expected);
+    });
+
     it("should not parse text value with tag", function() {
         const xmlData = `<score><c1>71<message>23</message>29</c1></score>`;
         const expected = {

--- a/src/json2xml.js
+++ b/src/json2xml.js
@@ -4,6 +4,7 @@ const buildOptions = require('./util').buildOptions;
 
 const defaultOptions = {
   attributeNamePrefix: '@_',
+  forceTextNode: false,
   attrNodeName: false,
   textNodeName: '#text',
   ignoreAttributes: true,
@@ -22,6 +23,7 @@ const defaultOptions = {
 
 const props = [
   'attributeNamePrefix',
+  'forceTextNode',
   'attrNodeName',
   'textNodeName',
   'ignoreAttributes',

--- a/src/node2json.js
+++ b/src/node2json.js
@@ -5,8 +5,16 @@ const util = require('./util');
 const convertToJson = function(node, options, parentTagName) {
   const jObj = {};
 
+
+
   // when no child node or attr is present
   if ((!node.child || util.isEmptyObject(node.child)) && (!node.attrsMap || util.isEmptyObject(node.attrsMap))) {
+    if(options.forceTextNode) {
+      const asArray = util.isTagNameInArrayMode(node.tagname, options.arrayMode, parentTagName)
+      jObj[options.textNodeName] = asArray ? [node.val] : node.val;
+      return jObj;
+    }
+    
     return util.isExist(node.val) ? node.val : '';
   }
 

--- a/src/parser.d.ts
+++ b/src/parser.d.ts
@@ -3,6 +3,7 @@ type X2jOptions = {
   attrNodeName: false | string;
   textNodeName: string;
   ignoreAttributes: boolean;
+  forceTextNode: boolean;
   ignoreNameSpace: boolean;
   allowBooleanAttributes: boolean;
   parseNodeValue: boolean;
@@ -23,6 +24,7 @@ type validationOptions = {
 type validationOptionsOptional = Partial<validationOptions>;
 type J2xOptions = {
   attributeNamePrefix: string;
+  forceTextNode: boolean;
   attrNodeName: false | string;
   textNodeName: string;
   ignoreAttributes: boolean;

--- a/src/xmlstr2xmlnode.js
+++ b/src/xmlstr2xmlnode.js
@@ -23,6 +23,7 @@ const defaultOptions = {
   attrNodeName: false,
   textNodeName: '#text',
   ignoreAttributes: true,
+  forceTextNode: false,
   ignoreNameSpace: false,
   allowBooleanAttributes: false, //a tag can have attributes without any value
   //ignoreRootElement : false,
@@ -48,6 +49,7 @@ const props = [
   'attributeNamePrefix',
   'attrNodeName',
   'textNodeName',
+  'forceTextNode',
   'ignoreAttributes',
   'ignoreNameSpace',
   'allowBooleanAttributes',


### PR DESCRIPTION
# Purpose / Goal
This PR is aimed to address issue with inconsistent parsing of leaf xml node depending on having attributes.
<!-- Please specify here what you're planning to achieve by this pull request and how it can help in regard of this work-space. -->

<!-- If it is a bug fix, please mention the issue number. If there is no issue has been raised but the PR directly then it should follow the template given to raise the issue. Like input, expected output, actual output etc. -->


# Type
* [x]New Feature

**Note** : Please ensure that you've read contribution [guidelines](https://github.com/NaturalIntelligence/fast-xml-parser/blob/master/docs/CONTRIBUTING.md) before raising this PR. If your PR is in progress, please prepend `[WIP]` in PR title. Your PR will be reviewed when `[WIP]` will be removed from the PR title.

# Benchmarks:
Before:
```
Running Suite: XML Parser benchmark
validation : 27318.44972450557 requests/second
xml to json : 25598.990886340493 requests/second
xml to json + json string : 22611.452524864457 requests/second
xml to json string : 3935.414783051609 requests/second
xml2js  : 7481.246469642413 requests/second
```
After:
```
Running Suite: XML Parser benchmark
validation : 16677.58957130443 requests/second
xml to json : 14956.997860785586 requests/second
xml to json + json string : 14365.03278613287 requests/second
xml to json string : 2784.9879303760063 requests/second
xml2js  : 5003.886648998017 requests/second
```
[Bookmark](https://github.com/NaturalIntelligence/fast-xml-parser/stargazers) this repository for further updates.
