### PR TITLE
Another way to export Arrays, preserving its' structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,8 @@ var defaultOptions = {
     supressEmptyNode: false,
     tagValueProcessor: a=> he.encode(a, { useNamedReferences: true}),// default is a=>a
     attrValueProcessor: a=> he.encode(a, {isAttributeValue: isAttribute, useNamedReferences: true})// default is a=>a
+    preserveArrays: false
+    
 };
 var parser = new Parser(defaultOptions);
 var xml = parser.parse(json_or_js_obj);
@@ -263,6 +265,8 @@ With the correct options, you can get the almost original XML without losing any
 * **supressEmptyNode** : If set to `true`, tags with no value (text or nested tags) are written as self closing tags.
 * **tagValueProcessor** : Process tag value during transformation. Like HTML encoding, word capitalization, etc. Applicable in case of string only.
 * **attrValueProcessor** : Process attribute value during transformation. Like HTML encoding, word capitalization, etc. Applicable in case of string only.
+* **preserveArrays** : If set to `true`, preserve arrays structure e.g. when you for this JSON {"Samples": [{"Sample": "1"}, {"Sample": "2"}]} this XML presentation would be generated <code> &lt;Samples&gt;&lt;Sample&gt;1&lt;/Sample&gt;&lt;Sample&gt;2&lt;Sample/&gt;&lt;Samples&gt; </code> instead of <code> &lt;Samples&gt;&lt;Sample&gt;1&lt;/Sample&gt;&lt;Samples&gt;&lt;Samples&gt;&lt;Sample&gt;2&lt;/Sample&gt;&lt;Samples&gt; </code>
+
 </details>
 
 ## Benchmark

--- a/spec/j2x_spec.js
+++ b/spec/j2x_spec.js
@@ -52,6 +52,21 @@ describe("XMLParser", function() {
         expect(result).toEqual(expected);
     });
 
+    it("should parse to XML with preserved array structure", function() {
+        const jObj = {
+            a: [
+                {"b": "val1"},
+                {"b": "val2"}
+            ]
+        };
+        const parser = new Parser({
+            preserveArrays: true
+        });
+        const result = parser.parse(jObj);
+        const expected = `<a><b>val1</b><b>val2</b></a>`;
+        expect(result).toEqual(expected);
+    });
+
     it("should supress undefined nodes", function() {
         const jObj = {
             a: {

--- a/src/parser.d.ts
+++ b/src/parser.d.ts
@@ -33,6 +33,7 @@ type J2xOptions = {
   supressEmptyNode: boolean;
   tagValueProcessor: (tagValue: string) => string;
   attrValueProcessor: (attrValue: string) => string;
+  preserveArrays: boolean;
 };
 type J2xOptionsOptional = Partial<J2xOptions>;
 


### PR DESCRIPTION
# Purpose / Goal
<!-- Please specify here what you're planning to achieve by this pull request and how it can help in regard of this work-space. -->

I'm implementing library for ReqIF file format. In this file format arrays should be exported in a specific way that is not supported by fast-xml-parser lib yet.

So I've added a new boolean option to j2xParser called "preserveArrays". By default it's set to false.
`const jObj = {
            a: [
                {"b": "val1"},
                {"b": "val2"}
            ]
        };`
exported to 
`<a><b>val1</b><b>val2</b></a>`
not to
`<a><b>val1</b></a><a><b>val2</b></a>`

# Type
Please mention the type of PR
<!-- choose one by changing [ ] to [x] -->
* [ ]Bug Fix
* [ ]Refactoring / Technology upgrade
* [x]New Feature

**Note** : Please ensure that you've read contribution [guidelines](https://github.com/NaturalIntelligence/fast-xml-parser/blob/master/docs/CONTRIBUTING.md) before raising this PR. If your PR is in progress, please prepend `[WIP]` in PR title. Your PR will be reviewed when `[WIP]` will be removed from the PR title.

Perf tests results:
1. Before: 
Running Suite: XML Parser benchmark
validation : 21447.86950120367 requests/second
xml to json : 19097.060136600496 requests/second
xml to json + json string : 17108.93585179627 requests/second
xml to json string : 2673.678902454078 requests/second
xml2js  : 6141.798187042608 requests/second

2. After: 
Running Suite: XML Parser benchmark
validation : 21351.56564350293 requests/second
xml to json : 19014.36968896438 requests/second
xml to json + json string : 17010.27411727562 requests/second
xml to json string : 2698.770095310595 requests/second
xml2js  : 5748.740866289303 requests/second

[Bookmark](https://github.com/NaturalIntelligence/fast-xml-parser/stargazers) this repository for further updates.
