### PR TITLE
added alwaysCreateTextNode option to force text node creation

### DIFF
--- a/spec/xmlParser_spec.js
+++ b/spec/xmlParser_spec.js
@@ -885,4 +885,29 @@ describe("XMLParser", function() {
         });
         expect(result).toEqual(expected);
     });
+
+    it("should create text node even if there are no attributes or node children", function() {
+        const xmlData = `<rootNode>
+        <tag>value</tag>
+        <tag2 some="attribute">12345</tag2>
+        </rootNode>`;
+        const expected = {
+            "rootNode": {
+                "tag": {
+                    "#text": "value"
+                },
+                "tag2": {
+                    "#text": 12345,
+                    "@_some": "attribute"
+                },
+            }
+        };
+
+        const result = parser.parse(xmlData, {
+            alwaysCreateTextNode : true,
+            ignoreAttributes: false,
+            parseAttributeValue: true
+        });
+        expect(result).toEqual(expected);
+    });
 });

--- a/src/node2json.js
+++ b/src/node2json.js
@@ -6,7 +6,7 @@ const convertToJson = function(node, options, parentTagName) {
   const jObj = {};
 
   // when no child node or attr is present
-  if ((!node.child || util.isEmptyObject(node.child)) && (!node.attrsMap || util.isEmptyObject(node.attrsMap))) {
+  if (!options.alwaysCreateTextNode && (!node.child || util.isEmptyObject(node.child)) && (!node.attrsMap || util.isEmptyObject(node.attrsMap))) {
     return util.isExist(node.val) ? node.val : '';
   }
 

--- a/src/parser.d.ts
+++ b/src/parser.d.ts
@@ -16,6 +16,7 @@ type X2jOptions = {
   tagValueProcessor: (tagValue: string, tagName: string) => string;
   attrValueProcessor: (attrValue: string, attrName: string) => string;
   stopNodes: string[];
+  alwaysCreateTextNode: boolean;
 };
 type strnumOptions = {
   hex: boolean;

--- a/src/xmlstr2xmlnode.js
+++ b/src/xmlstr2xmlnode.js
@@ -44,7 +44,8 @@ const defaultOptions = {
   attrValueProcessor: function(a, attrName) {
     return a;
   },
-  stopNodes: []
+  stopNodes: [],
+  alwaysCreateTextNode: false
   //decodeStrict: false,
 };
 
@@ -67,7 +68,8 @@ const props = [
   'attrValueProcessor',
   'parseTrueNumberOnly',
   'numParseOptions',
-  'stopNodes'
+  'stopNodes',
+  'alwaysCreateTextNode'
 ];
 exports.props = props;
 


### PR DESCRIPTION
# Purpose / Goal
This is a feature request for an option that makes the parser return a property for the textNodeName even if there are no attributes or node children. This prevents the downstream consuming JS to require checks for the text node and if it doesn't exist, use the property path itself.

Option would default to false so that the current behavior remains default.


# Type
Please mention the type of PR
<!-- choose one by changing [ ] to [x] -->
* [ ]Bug Fix
* [ ]Refactoring / Technology upgrade
* [x]New Feature

# Issue
[349](https://github.com/NaturalIntelligence/fast-xml-parser/issues/349)

# Perfomance tests
# Before
Running Suite: XML Parser benchmark
validation : 22482.344697710287 requests/second
xml to json : 15002.244861535037 requests/second
xml to json + json string : 13868.767986614608 requests/second
xml to json string : 2939.2827347641673 requests/second
xml2js  : 5709.279811841135 requests/second

# After
Running Suite: XML Parser benchmark
validation : 22732.947506604152 requests/second
xml to json : 15270.010037240734 requests/second
xml to json + json string : 14049.966577736843 requests/second
xml to json string : 2906.0090047436674 requests/second
xml2js  : 5690.710124230496 requests/second