### PR TITLE
Make skipLike optional for strnumOptions

### DIFF
--- a/src/parser.d.ts
+++ b/src/parser.d.ts
@@ -20,7 +20,7 @@ type X2jOptions = {
 type strnumOptions = {
   hex: boolean;
   leadingZeros: boolean,
-  skipLike: RegExp
+  skipLike?: RegExp
 }
 type X2jOptionsOptional = Partial<X2jOptions>;
 type validationOptions = {


### PR DESCRIPTION
# Purpose / Goal

Fixes https://github.com/NaturalIntelligence/fast-xml-parser/issues/368 by making `skipLike` optional in the `numParseOptions` for the parser.


# Type
Please mention the type of PR
<!-- choose one by changing [ ] to [x] -->
* [x]Bug Fix
* [ ]Refactoring / Technology upgrade
* [ ]New Feature

**Note** : Please ensure that you've read contribution [guidelines](https://github.com/NaturalIntelligence/fast-xml-parser/blob/master/docs/CONTRIBUTING.md) before raising this PR. If your PR is in progress, please prepend `[WIP]` in PR title. Your PR will be reviewed when `[WIP]` will be removed from the PR title.

[Bookmark](https://github.com/NaturalIntelligence/fast-xml-parser/stargazers) this repository for further updates.
