### PR TITLE
Better error location for unclosed tags

### DIFF
--- a/src/validator.js
+++ b/src/validator.js
@@ -35,7 +35,7 @@ exports.validate = function (xmlData, options) {
     }else if (xmlData[i] === '<') {
       //starting of tag
       //read until you reach to '>' avoiding any '>' in attribute value
-
+      let tagStartPos = i;
       i++;
       
       if (xmlData[i] === '!') {
@@ -105,8 +105,8 @@ exports.validate = function (xmlData, options) {
             return getErrorObject('InvalidTag', "Closing tag '"+tagName+"' can't have attributes or invalid starting.", getLineNumberForPosition(xmlData, i));
           } else {
             const otg = tags.pop();
-            if (tagName !== otg) {
-              return getErrorObject('InvalidTag', "Closing tag '"+otg+"' is expected inplace of '"+tagName+"'.", getLineNumberForPosition(xmlData, i));
+            if (tagName !== otg.tagName) {
+              return getErrorObject('InvalidTag', "Unclosed tag '"+otg.tagName+"'.", getLineNumberForPosition(xmlData, otg.tagStartPos));
             }
 
             //when there are no more tags, we reached the root level.
@@ -127,7 +127,7 @@ exports.validate = function (xmlData, options) {
           if (reachedRoot === true) {
             return getErrorObject('InvalidXml', 'Multiple possible root nodes found.', getLineNumberForPosition(xmlData, i));
           } else {
-            tags.push(tagName);
+            tags.push({tagName, tagStartPos});
           }
           tagFound = true;
         }


### PR DESCRIPTION
Fixes #370

# Purpose / Goal
For unclosed tags, `validate` now reports the opening tag's line instead of the line where the parent is closed. See #370.

I only changed `src/validator.js`. I tried re-building `lib/`, but `yarn run bundle` creates a large number of changed files, so I'm not sure if that is the correct call.

# Type
Please mention the type of PR
<!-- choose one by changing [ ] to [x] -->
* [x]Bug Fix
* [ ]Refactoring / Technology upgrade
* [ ]New Feature

**Note** : Please ensure that you've read contribution [guidelines](https://github.com/NaturalIntelligence/fast-xml-parser/blob/master/docs/CONTRIBUTING.md) before raising this PR. If your PR is in progress, please prepend `[WIP]` in PR title. Your PR will be reviewed when `[WIP]` will be removed from the PR title.

[Bookmark](https://github.com/NaturalIntelligence/fast-xml-parser/stargazers) this repository for further updates.
