### PR TITLE
minifix markup

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ var options = {
       hex: true,
       leadingZeros: true,
       //skipLike: /\+[0-9]{10}/
-    }
+    },
     arrayMode: false, //"strict"
     attrValueProcessor: (val, attrName) => he.decode(val, {isAttributeValue: true}),//default is a=>a
     tagValueProcessor : (val, tagName) => he.decode(val), //default is a=>a


### PR DESCRIPTION
# Purpose / Goal
Fix how it looks like on [npm](https://www.npmjs.com/package/fast-xml-parser) by making text more readable and copiable:

Before:
<img width="782" alt="Screenshot 2021-10-13 at 10 51 51" src="https://user-images.githubusercontent.com/5558911/137091587-f1038cc2-dfb9-4bcf-9400-da572a3bf09b.png">

After:
![image](https://user-images.githubusercontent.com/5558911/137091892-0e401747-d1df-42ff-a405-7a529c0ec791.png)
