### PR TITLE
fix: make `nyc` a devDep

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "he": "^1.2.0",
     "jasmine": "^3.6.4",
     "nimnjs": "^1.3.2",
+    "nyc": "^15.1.0",
     "prettier": "^1.19.1",
     "publish-please": "^5.5.2",
     "webpack": "^4.46.0",
@@ -88,7 +89,6 @@
     "url": "https://paypal.me/naturalintelligence"
   },
   "dependencies": {
-    "nyc": "^15.1.0",
     "strnum": "^1.0.4"
   }
 }


### PR DESCRIPTION
fixes https://github.com/NaturalIntelligence/fast-xml-parser/issues/384