### PR TITLE
Change XMLBuilder typings to expose correct function name

### DIFF
--- a/src/fxp.d.ts
+++ b/src/fxp.d.ts
@@ -70,5 +70,5 @@ export class XMLValidator{
 }
 export class XMLBuilder {
   constructor(options: XmlBuilderOptionsOptional);
-  parse(options: any): any;
+  build(jObj: any): any;
 }


### PR DESCRIPTION
The typings defined `parse`, even if the actual class exposes `build`.

Also changing the parameter name from `options` to `jObj`

# Purpose / Goal
Improve the experience using XMLBuilder in v4 with Typescript by using the correct function name, `build` instead of `parse`.

This pull request doesn't have an issue connected with it, as it's quite small.

**Expected**:

When using XMLBuilder with Typescript, it should suggest and accept `new Builder(options).build`

**Actual**:

When using XMLBuilder with Typescript, it suggests and accepts `new Builder(options).parse`, which is not defined on the actual class. Attempting to use `new Builder(options).build` raises a Typescript error, and we need to use `// @ts-ignore` to be able to build. 

**Benchmarks**:

Shouldn't affect performance, but just to show that I skimmed through the contribution guidelines:

```
node XmlBuilder.js
Running Suite: XML Builder benchmark
fxp : 61781.672750776546 requests/second
fxp - preserve order : 331720539.54804766 requests/second
xml2js  : 3493.707511368985 requests/second

node XmlParser.js
Running Suite: XML Parser benchmark
fxp v3 : 10805.277764633815 requests/second
fxp : 10587.343533433563 requests/second
fxp - preserve order : 11910.25930150525 requests/second
xml2js  : 2377.2217768943174 requests/second
```


# Type
Please mention the type of PR
<!-- choose one by changing [ ] to [x] -->
* [x] Bug Fix
* [ ] Refactoring / Technology upgrade
* [ ] New Feature

**Note** : Please ensure that you've read contribution [guidelines](https://github.com/NaturalIntelligence/fast-xml-parser/blob/master/docs/CONTRIBUTING.md) before raising this PR. If your PR is in progress, please prepend `[WIP]` in PR title. Your PR will be reviewed when `[WIP]` will be removed from the PR title.

[Bookmark](https://github.com/NaturalIntelligence/fast-xml-parser/stargazers) this repository for further updates.
