### PR TITLE
Adds missing commata to XMLparseOptions docs

### DIFF
--- a/docs/v4/2.XMLparseOptions.md
+++ b/docs/v4/2.XMLparseOptions.md
@@ -133,7 +133,7 @@ const xmlData = `<root a="nice" b="very nice" ><a>wow</a></root>`;
 
 const options = {
     ignoreAttributes: false,
-    attributeNamePrefix : "@_"
+    attributeNamePrefix : "@_",
     attributesGroupName : "@_"
 };
 const parser = new XMLParser(options);
@@ -601,7 +601,7 @@ const xmlData = `<root some:a="nice" ><any:a>wow</any:a></root>`;
 
 const options = {
     ignoreAttributes: false,
-    attributeNamePrefix : "@_"
+    attributeNamePrefix : "@_",
     removeNSPrefix: true
 };
 const parser = new XMLParser(options);


### PR DESCRIPTION
# Purpose / Goal
<!-- Please specify here what you're planning to achieve by this pull request and how it can help in regard of this work-space. -->
Probably this comes from a copy/paste mistake, in the documentation of parserOptions on two places a comma was missing.
<!-- If it is a bug fix, please mention the issue number. If there is no issue has been raised but the PR directly then it should follow the template given to raise the issue. Like input, expected output, actual output etc. -->


# Type
Please mention the type of PR
<!-- choose one by changing [ ] to [x] -->
* [x]Bug Fix
* [ ]Refactoring / Technology upgrade
* [ ]New Feature

**Note** : Please ensure that you've read contribution [guidelines](https://github.com/NaturalIntelligence/fast-xml-parser/blob/master/docs/CONTRIBUTING.md) before raising this PR. If your PR is in progress, please prepend `[WIP]` in PR title. Your PR will be reviewed when `[WIP]` will be removed from the PR title.

[Bookmark](https://github.com/NaturalIntelligence/fast-xml-parser/stargazers) this repository for further updates.
