### PR TITLE
Remove duplicate tag processor call

### DIFF
--- a/spec/j2x_spec.js
+++ b/spec/j2x_spec.js
@@ -299,6 +299,56 @@ textvalue&gt;  <tag>
     expect(result).toEqual(expected);
   });
 
+  it("should not double encode tag values", function() {
+    const jObj = {
+      a: {
+        element: {
+          subelement: {
+            "#text": "foo & bar",
+            "@": {"staticMessage": "bar"}
+          }
+        },
+        only_text_array: [
+          {
+            '#text': 'text & value'
+          }
+        ],
+        regular_array: [
+          {
+            '#text': 'text & value',
+            '@': {
+              'f': 'abc'
+            }
+          }
+        ],
+        only_text_obj: {
+          '#text': 'another text & val'
+        }
+      }
+    };
+    const builder = new XMLBuilder({
+      attributesGroupName: "@",
+      processEntities: false,
+      format: true,
+      tagValueProcessor: (tagName, a) => { a = '' + a; return he.encode(a, { useNamedReferences: true }) },
+      attributeValueProcessor: (attrName, a) => he.encode(a, { isAttributeValue: true, useNamedReferences: true }),
+      attributeNamePrefix: '',
+      ignoreAttributes: false,
+      suppressEmptyNode: true
+    });
+    const result = builder.build(jObj);
+    const expected = `<a>
+  <element>
+    <subelement staticMessage="bar">foo &amp; bar</subelement>
+  </element>
+  <only_text_array>text &amp; value</only_text_array>
+  <regular_array f="abc">text &amp; value</regular_array>
+  <only_text_obj>another text &amp; val</only_text_obj>
+</a>
+`;
+    expect(result).toEqual(expected);
+  });
+
 
     it("should format when parsing to XML", function() {
         const jObj = {

--- a/src/xmlbuilder/json2xml.js
+++ b/src/xmlbuilder/json2xml.js
@@ -192,8 +192,7 @@ function buildEmptyObjNode(val, key, attrStr, level) {
 }
 
 function buildTextValNode(val, key, attrStr, level) {
-  let textValue = this.options.tagValueProcessor(key, val);
-  textValue = this.replaceEntitiesValue(textValue);
+  const textValue = this.replaceEntitiesValue(val);
   
   return (
     this.indentate(level) + '<' + key + attrStr + '>' +


### PR DESCRIPTION
# Purpose / Goal
This fixes a bug where JSON elements that have a `#text` property but do not have any attribute properties are written in the XML string having been called against the `tagValueProcessor` twice.

The fix just removes the duplicate `tagValueProcessor` call as this is extraneous and does not cause a regression issue.

# Type
Please mention the type of PR

- [x] Bug Fix
- [ ] Refactoring / Technology upgrade
- [ ] New Feature

# Issue
Fixes #425;

# Perfomance tests (`XmlBuilder.js`)
# Before
fxp : 86512.97288990665 requests/second
fxp - preserve order : 173967538.9033842 requests/second
xml2js  : 17897.584436115638 requests/second

# After
Running Suite: XML Builder benchmark
fxp : 89999.27338492977 requests/second
fxp - preserve order : 174703313.43980005 requests/second
xml2js  : 17826.2562878387 requests/second