### PR TITLE
fix: ReferenceError when Bundled with Strict

### DIFF
--- a/src/xmlbuilder/orderedJs2Xml.js
+++ b/src/xmlbuilder/orderedJs2Xml.js
@@ -72,7 +72,7 @@ function propName(obj){
 function attr_to_str(attrMap, options){
     let attrStr = "";
     if(attrMap && !options.ignoreAttributes){
-        for( attr in attrMap){
+        for (let attr in attrMap){
             let attrVal = options.attributeValueProcessor(attr, attrMap[attr]);
             attrVal = replaceEntitiesValue(attrVal, options);
             if(attrVal === true && options.suppressBooleanAttributes){


### PR DESCRIPTION
# Purpose / Goal

Fix #430 to allow library to work in environments where bundler set javascript to strict.
Add missing `let` in `for-in` loop.

# Type
Please mention the type of PR
* [X]Bug Fix
* [ ]Refactoring / Technology upgrade
* [ ]New Feature
