### PR TITLE
Implement API to pretty format XML strings

### DIFF
--- a/spec/formatter_spec.js
+++ b/spec/formatter_spec.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const {format} = require('../src/fxp');
+
+describe('XML formatter', () => {
+  it('should format simple document', () => {
+    const result = format('<data><item>1</item></data>');
+    expect(result).toBe(`
+<data>
+  <item>
+    1
+  </item>
+</data>`);
+  });
+
+  it('should preserve XML PI tag', () => {
+    const result = format('<?xml version="1.0"?><data>hello</data>');
+    expect(result).toBe(`
+<?xml   version="1.0"?>
+<data>
+  hello
+</data>`);
+  });
+
+  it('should preserve self-closed tags', () => {
+    const result = format('<data><self-closed/></data>');
+    expect(result).toBe(`
+<data>
+  <self-closed/>
+</data>`);
+  });
+
+  it('should preserve comments', () => {
+    const result = format('<data><!-- comment --><value>1</value></data>');
+    expect(result).toBe(`
+<data>
+  <!-- comment -->
+  <value>
+    1
+  </value>
+</data>`);
+  });
+
+  it('should preserve attributes', () => {
+    const result = format('<data kind="text">hello</data>');
+    expect(result).toBe(`
+<data kind="text">
+  hello
+</data>`);
+  });
+
+  xit('should preserve closing tag after empty content', () => {
+    const result = format('<empty></empty>');
+    expect(result).toBe(`
+<empty>
+</empty>`);
+  });
+});

--- a/src/formatter.js
+++ b/src/formatter.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const XMLParser = require('./xmlparser/XMLParser');
+const XMLBuilder = require('./xmlbuilder/json2xml');
+
+exports.format = function(xmlString) {
+  const options = {
+    alwaysCreateTextNode: true,
+    cdataPropName: '#cdata',
+    commentPropName: '#comment',
+    ignoreAttributes: false,
+    preserveOrder: true,
+    processEntities: false,
+    trimValues: false,
+    suppressEmptyNode: true,
+    format: true,
+  };
+
+  const parser = new XMLParser(options);
+  const data = parser.parse(xmlString);
+
+  const builder = new XMLBuilder(options);
+  const result = builder.build(data);
+
+  return result;
+};

--- a/src/fxp.d.ts
+++ b/src/fxp.d.ts
@@ -86,3 +86,5 @@ export class XMLBuilder {
   constructor(options: XmlBuilderOptionsOptional);
   build(jObj: any): any;
 }
+
+export function format(xmlString: string): string;

--- a/src/fxp.js
+++ b/src/fxp.js
@@ -3,9 +3,11 @@
 const validator = require('./validator');
 const XMLParser = require('./xmlparser/XMLParser');
 const XMLBuilder = require('./xmlbuilder/json2xml');
+const {format} = require('./formatter');
 
 module.exports = {
   XMLParser: XMLParser,
   XMLValidator: validator,
-  XMLBuilder: XMLBuilder
-}
+  XMLBuilder: XMLBuilder,
+  format,
+};


### PR DESCRIPTION
# Purpose / Goal
<!-- Please specify here what you're planning to achieve by this pull request and how it can help in regard of this work-space. -->

I am looking for an easy to use API for formatting (pretty-printing) XML. Something like `xmllint --format`.

fast-xml-parser already has both XMLParser and XMLBuilder classes that can preserve all bits and pieces (comments, processing instructions, etc.), but it's not clear what settings to use for pretty printing.

In my pull request, I am adding a simple function accepting an XML string and returning back the formatted version. Under the hood, the function configures XMLParser and XMLBuilder in such a way so that as much XML data is preserved as possible.

### Example use:

```js
const {format} = require('fast-xml-parser');
const result = format('<data><!-- comment --><value>1</value></data>');

/* result:

<data>
  <!-- comment -->
  <value>
    1
  </value>
</data>

*/
```

<!-- If it is a bug fix, please mention the issue number. If there is no issue has been raised but the PR directly then it should follow the template given to raise the issue. Like input, expected output, actual output etc. -->

Related:
- #403
- https://github.com/NaturalIntelligence/fast-xml-parser/blob/master/docs/v4/3.XMLBuilder.md#restoring-original-xml

# Type
Please mention the type of PR
<!-- choose one by changing [ ] to [x] -->
* [ ] Bug Fix
* [ ] Refactoring / Technology upgrade
* [x] New Feature

<!--
**Note** : Please ensure that you've read contribution [guidelines](https://github.com/NaturalIntelligence/fast-xml-parser/blob/master/docs/CONTRIBUTING.md) before raising this PR. If your PR is in progress, please prepend `[WIP]` in PR title. Your PR will be reviewed when `[WIP]` will be removed from the PR title.

[Bookmark](https://github.com/NaturalIntelligence/fast-xml-parser/stargazers) this repository for further updates.
-->