### PR TITLE
Fix CDATA parsing returning empty string when value = 0

### DIFF
--- a/src/xmlparser/OrderedObjParser.js
+++ b/src/xmlparser/OrderedObjParser.js
@@ -251,7 +251,7 @@ const parseXml = function(xmlData) {
           currentNode.add(this.options.cdataPropName, [ { [this.options.textNodeName] : tagExp } ]);
         }else{
           let val = this.parseTextData(tagExp, currentNode.tagname, jPath, true, false, true);
-          if(!val) val = "";
+          if(val == undefined) val = "";
           currentNode.add(this.options.textNodeName, val);
         }
         


### PR DESCRIPTION
# Purpose / Goal
In V4, parsing CDATA with value 0 returns an empty string
In v3, it returned the string '0'

# Type
Please mention the type of PR
* [X]Bug Fix
* [ ]Refactoring / Technology upgrade
* [ ]New Feature

# Input
```
<latitude>
    <![CDATA[ 0 ]]>
</latitude>
```

# Expected output
`latitude = 0`

# Actual output
`latitude = ''`
