### PR TITLE
Fix stopNodes when same tag appears inside node

### DIFF
--- a/spec/stopNodes_spec.js
+++ b/spec/stopNodes_spec.js
@@ -295,4 +295,29 @@ describe("XMLParser StopNodes", function() {
   
         expect(expected).toEqual(result);
   });
+
+  it("should not incorrectly close the stop node if the same tag name appears inside", function() {
+        const xmlData = `<issue><title>test 1</title><fix1><p>p 1</p><div class="show">div 1</div><other><fix1>more</fix1></other></fix1></issue>`;
+        const expected = {
+          issue: {
+            title: 'test 1',
+            fix1: '<p>p 1</p><div class="show">div 1</div><other><fix1>more</fix1></other>',
+          },
+        };
+
+        const options = {
+          attributeNamePrefix: "",
+            ignoreAttributes:    false,
+            parseAttributeValue: true,
+            stopNodes: ["issue.fix1"]
+      };
+      const parser = new XMLParser(options);
+      let result = parser.parse(xmlData);
+
+        // console.log(JSON.stringify(result,null,4));
+        expect(result).toEqual(expected);
+
+        result = XMLValidator.validate(xmlData);
+        expect(result).toBe(true);
+  });
 });

--- a/spec/stopNodes_spec.js
+++ b/spec/stopNodes_spec.js
@@ -297,11 +297,12 @@ describe("XMLParser StopNodes", function() {
   });
 
   it("should not incorrectly close the stop node if the same tag name appears inside", function() {
-        const xmlData = `<issue><title>test 1</title><fix1><p>p 1</p><div class="show">div 1</div><other><fix1>more</fix1></other></fix1></issue>`;
+        const xmlData = `<issue><title>test 1</title><fix1><p>p 1</p><div class="show">div 1</div><other><fix1>more</fix1></other></fix1><last>something</last></issue>`;
         const expected = {
           issue: {
             title: 'test 1',
             fix1: '<p>p 1</p><div class="show">div 1</div><other><fix1>more</fix1></other>',
+            last: 'something'
           },
         };
 

--- a/src/xmlparser/OrderedObjParser.js
+++ b/src/xmlparser/OrderedObjParser.js
@@ -507,9 +507,12 @@ function readStopNodeData(xmlData, tagName, i){
         } else {
           const tagData = readTagExp(xmlData, i, '>')
 
-          const openTagName = tagData && tagData.tagName;
-          if (openTagName === tagName) {
-            openTagCount++;
+          if (tagData) {
+            const openTagName = tagData && tagData.tagName;
+            if (openTagName === tagName) {
+              openTagCount++;
+            }
+            i=tagData.closeIndex;
           }
         }
       }

--- a/src/xmlparser/OrderedObjParser.js
+++ b/src/xmlparser/OrderedObjParser.js
@@ -486,17 +486,32 @@ function readTagExp(xmlData,i, removeNSPrefix, closingChar = ">"){
  */
 function readStopNodeData(xmlData, tagName, i){
   const startIndex = i;
+  // Starting at 1 since we already have an open tag
+  let openTagCount = 1;
+
   for (; i < xmlData.length; i++) {
-    if( xmlData[i] === "<" && xmlData[i+1] === "/"){ 
-        const closeIndex = findClosingIndex(xmlData, ">", i, `${tagName} is not closed`);
-        let closeTagName = xmlData.substring(i+2,closeIndex).trim();
-        if(closeTagName === tagName){
-          return {
-            tagContent: xmlData.substring(startIndex, i),
-            i : closeIndex
+    if( xmlData[i] === "<"){ 
+      if (xmlData[i+1] === "/") {
+          const closeIndex = findClosingIndex(xmlData, ">", i, `${tagName} is not closed`);
+          let closeTagName = xmlData.substring(i+2,closeIndex).trim();
+          if(closeTagName === tagName){
+            openTagCount--;
+            if (openTagCount === 0) {
+              return {
+                tagContent: xmlData.substring(startIndex, i),
+                i : closeIndex
+              }
+            }
+          }
+          i=closeIndex;
+        } else {
+          const tagData = readTagExp(xmlData, i, '>')
+
+          const openTagName = tagData && tagData.tagName;
+          if (openTagName === tagName) {
+            openTagCount++;
           }
         }
-        i=closeIndex;
       }
   }//end for loop
 }


### PR DESCRIPTION
# Purpose / Goal
When using the `stopNodes` option, if tags with the same name as the stop node are contained in the stop node, we will incorrectly close the stopped node early. This fixes that issue.

Fixes: https://github.com/NaturalIntelligence/fast-xml-parser/issues/455


# Type
Please mention the type of PR
<!-- choose one by changing [ ] to [x] -->
* [x] Bug Fix
* [ ] Refactoring / Technology upgrade
* [ ] New Feature

**Note** : Please ensure that you've read contribution [guidelines](https://github.com/NaturalIntelligence/fast-xml-parser/blob/master/docs/CONTRIBUTING.md) before raising this PR. If your PR is in progress, please prepend `[WIP]` in PR title. Your PR will be reviewed when `[WIP]` will be removed from the PR title.

[Bookmark](https://github.com/NaturalIntelligence/fast-xml-parser/stargazers) this repository for further updates.
