### PR TITLE
Added Selective Parsing of Attributes by Tag Name

### DIFF
--- a/src/xmlparser/OptionsBuilder.js
+++ b/src/xmlparser/OptionsBuilder.js
@@ -10,6 +10,7 @@ const defaultOptions = {
     //ignoreRootElement : false,
     parseTagValue: true,
     parseAttributeValue: false,
+    attributeTargetTags: [], // Optional Array of Tag Names that will have attributes parsed
     trimValues: true, //Trim string values of tag and attributes
     cdataPropName: false,
     numberParseOptions: {

--- a/src/xmlparser/OrderedObjParser.js
+++ b/src/xmlparser/OrderedObjParser.js
@@ -122,10 +122,10 @@ function resolveNameSpace(tagname) {
 const attrsRegx = new RegExp('([^\\s=]+)\\s*(=\\s*([\'"])([\\s\\S]*?)\\3)?', 'gm');
 
 function buildAttributesMap(attrStr, jPath) {
-  if (!this.options.ignoreAttributes && typeof attrStr === 'string') {
+  const tagName = jPath.split('.').pop();
+  if (!this.options.ignoreAttributes && typeof attrStr === 'string' && (!this.options.attributeTargetTags.length || this.options.attributeTargetTags.includes(tagName))) {
     // attrStr = attrStr.replace(/\r?\n/g, ' ');
     //attrStr = attrStr || attrStr.trim();
-
     const matches = util.getAllMatches(attrStr, attrsRegx);
     const len = matches.length; //don't make it inline
     const attrs = {};


### PR DESCRIPTION
Modified Options Builder to include new option - attributeTargetTags - Array
Modified OrderedObjParser to check for attributeTargetTags and see if TagName is in the array

# Purpose / Goal
Simple addition to only have attributes parsed from specific TagNames. This need arose from messy source xml where parsing all the attributes complicated and cluttered the resulting JSON. This will allow an array of tag names to be passed into options to filter what tags get their attributes expanded.

This addresses my idea #458. After posting about it, I realized it wouldn't take much to add it so I thought it would be a good chance to make my first commit to a module i like. I hope you like it!

# Type
Please mention the type of PR
* [ ]Bug Fix
* [ ]Refactoring / Technology upgrade
* [x]New Feature

**Note** : Please ensure that you've read contribution [guidelines](https://github.com/NaturalIntelligence/fast-xml-parser/blob/master/docs/CONTRIBUTING.md) before raising this PR. If your PR is in progress, please prepend `[WIP]` in PR title. Your PR will be reviewed when `[WIP]` will be removed from the PR title.

[Bookmark](https://github.com/NaturalIntelligence/fast-xml-parser/stargazers) this repository for further updates.
