### PR TITLE
Fix: Valid DTD declerations causing "Invalid DOCTYPE" error & Allow angle brackets within comments in DOCTYPE

### DIFF
--- a/src/xmlparser/DocTypeReader.js
+++ b/src/xmlparser/DocTypeReader.js
@@ -38,6 +38,31 @@ function readDocType(xmlData, i){
                 ){
                     //Not supported
                     i += 8;
+                }else if( hasBody && 
+                    xmlData[i+1] === '!' &&
+                     xmlData[i+2] === 'A' &&
+                     xmlData[i+3] === 'T' &&
+                     xmlData[i+4] === 'T' &&
+                     xmlData[i+5] === 'L' &&
+                     xmlData[i+6] === 'I' &&
+                     xmlData[i+7] === 'S' &&
+                     xmlData[i+8] === 'T'
+                ){
+                    //Not supported
+                    i += 8;
+                }else if( hasBody && 
+                    xmlData[i+1] === '!' &&
+                     xmlData[i+2] === 'N' &&
+                     xmlData[i+3] === 'O' &&
+                     xmlData[i+4] === 'T' &&
+                     xmlData[i+5] === 'A' &&
+                     xmlData[i+6] === 'T' &&
+                     xmlData[i+7] === 'I' &&
+                     xmlData[i+8] === 'O' &&
+                     xmlData[i+9] === 'N'
+                ){
+                    //Not supported
+                    i += 9;
                 }else if( //comment
                     xmlData[i+1] === '!' &&
                     xmlData[i+2] === '-' &&

--- a/src/xmlparser/DocTypeReader.js
+++ b/src/xmlparser/DocTypeReader.js
@@ -14,7 +14,16 @@ function readDocType(xmlData, i){
         let hasBody = false, entity = false, comment = false;
         let exp = "";
         for(;i<xmlData.length;i++){
-            if (xmlData[i] === '<') {
+            if (comment) {
+                if (xmlData[i] === '-' && xmlData[i+1] === '-') {   
+                    if (xmlData[i+2] === '>') {
+                        i += 2;
+                        comment = false;
+                    }else{
+                        throw new Error(`The string "--" (double-hyphen) must not occur within XML comments`);
+                    }
+                }
+            } else if (xmlData[i] === '<') {
                 if( hasBody && 
                     xmlData[i+1] === '!' &&
                     xmlData[i+2] === 'E' &&
@@ -68,20 +77,16 @@ function readDocType(xmlData, i){
                     xmlData[i+2] === '-' &&
                     xmlData[i+3] === '-'
                 ){
+                    i += 3;
                     comment = true;
+                    continue
                 }else{
                     throw new Error("Invalid DOCTYPE");
                 }
                 angleBracketsCount++;
                 exp = "";
             } else if (xmlData[i] === '>') {
-                if(comment){
-                    if( xmlData[i - 1] === "-" && xmlData[i - 2] === "-"){
-                        comment = false;
-                    }else{
-                        throw new Error(`Invalid XML comment in DOCTYPE`);
-                    }
-                }else if(entity){
+                if(entity){
                     parseEntityExp(exp, entities);
                     entity = false;
                 }

--- a/src/xmlparser/DocTypeReader.js
+++ b/src/xmlparser/DocTypeReader.js
@@ -3,11 +3,11 @@ function readDocType(xmlData, i){
     
     const entities = {};
     if( xmlData[i + 3] === 'O' &&
-         xmlData[i + 4] === 'C' &&
-         xmlData[i + 5] === 'T' &&
-         xmlData[i + 6] === 'Y' &&
-         xmlData[i + 7] === 'P' &&
-         xmlData[i + 8] === 'E')
+        xmlData[i + 4] === 'C' &&
+        xmlData[i + 5] === 'T' &&
+        xmlData[i + 6] === 'Y' &&
+        xmlData[i + 7] === 'P' &&
+        xmlData[i + 8] === 'E')
     {    
         i = i+9;
         let angleBracketsCount = 1;
@@ -16,50 +16,50 @@ function readDocType(xmlData, i){
         for(;i<xmlData.length;i++){
             if (xmlData[i] === '<') {
                 if( hasBody && 
-                     xmlData[i+1] === '!' &&
-                     xmlData[i+2] === 'E' &&
-                     xmlData[i+3] === 'N' &&
-                     xmlData[i+4] === 'T' &&
-                     xmlData[i+5] === 'I' &&
-                     xmlData[i+6] === 'T' &&
-                     xmlData[i+7] === 'Y'
+                    xmlData[i+1] === '!' &&
+                    xmlData[i+2] === 'E' &&
+                    xmlData[i+3] === 'N' &&
+                    xmlData[i+4] === 'T' &&
+                    xmlData[i+5] === 'I' &&
+                    xmlData[i+6] === 'T' &&
+                    xmlData[i+7] === 'Y'
                 ){
                     i += 7;
                     entity = true;
                 }else if( hasBody && 
                     xmlData[i+1] === '!' &&
-                     xmlData[i+2] === 'E' &&
-                     xmlData[i+3] === 'L' &&
-                     xmlData[i+4] === 'E' &&
-                     xmlData[i+5] === 'M' &&
-                     xmlData[i+6] === 'E' &&
-                     xmlData[i+7] === 'N' &&
-                     xmlData[i+8] === 'T'
+                    xmlData[i+2] === 'E' &&
+                    xmlData[i+3] === 'L' &&
+                    xmlData[i+4] === 'E' &&
+                    xmlData[i+5] === 'M' &&
+                    xmlData[i+6] === 'E' &&
+                    xmlData[i+7] === 'N' &&
+                    xmlData[i+8] === 'T'
                 ){
                     //Not supported
                     i += 8;
                 }else if( hasBody && 
                     xmlData[i+1] === '!' &&
-                     xmlData[i+2] === 'A' &&
-                     xmlData[i+3] === 'T' &&
-                     xmlData[i+4] === 'T' &&
-                     xmlData[i+5] === 'L' &&
-                     xmlData[i+6] === 'I' &&
-                     xmlData[i+7] === 'S' &&
-                     xmlData[i+8] === 'T'
+                    xmlData[i+2] === 'A' &&
+                    xmlData[i+3] === 'T' &&
+                    xmlData[i+4] === 'T' &&
+                    xmlData[i+5] === 'L' &&
+                    xmlData[i+6] === 'I' &&
+                    xmlData[i+7] === 'S' &&
+                    xmlData[i+8] === 'T'
                 ){
                     //Not supported
                     i += 8;
                 }else if( hasBody && 
                     xmlData[i+1] === '!' &&
-                     xmlData[i+2] === 'N' &&
-                     xmlData[i+3] === 'O' &&
-                     xmlData[i+4] === 'T' &&
-                     xmlData[i+5] === 'A' &&
-                     xmlData[i+6] === 'T' &&
-                     xmlData[i+7] === 'I' &&
-                     xmlData[i+8] === 'O' &&
-                     xmlData[i+9] === 'N'
+                    xmlData[i+2] === 'N' &&
+                    xmlData[i+3] === 'O' &&
+                    xmlData[i+4] === 'T' &&
+                    xmlData[i+5] === 'A' &&
+                    xmlData[i+6] === 'T' &&
+                    xmlData[i+7] === 'I' &&
+                    xmlData[i+8] === 'O' &&
+                    xmlData[i+9] === 'N'
                 ){
                     //Not supported
                     i += 9;

--- a/src/xmlparser/DocTypeReader.js
+++ b/src/xmlparser/DocTypeReader.js
@@ -1,4 +1,3 @@
-//TODO: handle comments
 function readDocType(xmlData, i){
     
     const entities = {};


### PR DESCRIPTION
When I was trying to parse a XML containing attribute list declarations the parser threw the error "Invalid DOCTYPE". I figured that `readDocType(...)` wasn't aware of attribute list (`<!ATTLIST>`) and notation (`<!NOTATION>`) declarations, which causes the parser to throw an error despite them being valid.

Edit: 
Later when I was trying to parse another XML I noticed that that the parser could bug out if there's a `<` (left angle bracket) within a comment, or throw the error "Invalid XML comment in DOCTYPE" if there's a `>` (right angle bracket) within a comment. I've included a fix for this too in this PR. I also made the string "--" (double-hyphen) prohibited within comments to respect the XML specifications.

# Purpose / Goal
<!-- Please specify here what you're planning to achieve by this pull request and how it can help in regard of this work-space. -->

<!-- If it is a bug fix, please mention the issue number. If there is no issue has been raised but the PR directly then it should follow the template given to raise the issue. Like input, expected output, actual output etc. -->
- Adds awareness of missing DTD declarations
- Allow angle brackets within comments in DOCTYPE

# Type
Please mention the type of PR
<!-- choose one by changing [ ] to [x] -->
* [x]Bug Fix
* [ ]Refactoring / Technology upgrade
* [ ]New Feature

**Note** : Please ensure that you've read contribution [guidelines](https://github.com/NaturalIntelligence/fast-xml-parser/blob/master/docs/CONTRIBUTING.md) before raising this PR. If your PR is in progress, please prepend `[WIP]` in PR title. Your PR will be reviewed when `[WIP]` will be removed from the PR title.

[Bookmark](https://github.com/NaturalIntelligence/fast-xml-parser/stargazers) this repository for further updates.

# Benchmark
#### Before
```
$ git checkout master
Already on 'master'
Your branch is up to date with 'origin/master'.

fast-xml-parser/benchmark (master)
$ node ./XmlParser.js 
Running Suite: XML Parser benchmark
fxp v3 : 48925.42004066759 requests/second
fxp : 32984.85177084433 requests/second
fxp - preserve order : 36796.17289188007 requests/second
xmlbuilder2 : 12489.23037965013 requests/second
xml2js  : 8390.77788439448 requests/second
```
#### After
```
$ git checkout patch-doctype-decl 
Switched to branch 'patch-doctype-decl'
Your branch is up to date with 'origin/patch-doctype-decl'.

fast-xml-parser/benchmark (patch-doctype-decl)
$ node ./XmlParser.js
Running Suite: XML Parser benchmark
fxp v3 : 48470.96001554136 requests/second
fxp : 33241.64972804925 requests/second
fxp - preserve order : 35427.0501592926 requests/second
xmlbuilder2 : 12335.001518949128 requests/second
xml2js  : 8274.55732009545 requests/second
```
