### PR TITLE
Add transformTagName option to transform tag names when parsing

### DIFF
--- a/spec/transform_tagname_spec.js
+++ b/spec/transform_tagname_spec.js
@@ -1,0 +1,36 @@
+"use strict";
+
+const {XMLParser} = require("../src/fxp");
+
+describe("XMLParser", function() {
+    it("should parse lowercase tagnames", function() {
+        const xmlData = `<?xml version='1.0'?>
+          <root>
+            <person>Person 1</person>
+            <Person>Person 2</Person>
+            <PERSON>Person 3</PERSON>
+            <person>Person 4</person>
+          </root>
+        `;
+
+        const parser = new XMLParser({
+            // transformTagName: (tagName) => tagName
+            ignoreDeclaration: true,
+            transformTagName: (tagName) => tagName.toLowerCase()
+        });
+        let result = parser.parse(xmlData);
+
+        const expected = {
+            "root": {
+                "person": [
+                    "Person 1",
+                    "Person 2",
+                    "Person 3",
+                    "Person 4"
+                ]
+            }
+        };
+
+        expect(result).toEqual(expected);
+    });
+});

--- a/src/fxp.d.ts
+++ b/src/fxp.d.ts
@@ -22,6 +22,7 @@ type X2jOptions = {
   htmlEntities: boolean;
   ignoreDeclaration: boolean;
   ignorePiTags: boolean;
+  transformTagName: ((tagName: string) => string) | false;
 };
 type strnumOptions = {
   hex: boolean;

--- a/src/xmlbuilder/json2xml.js
+++ b/src/xmlbuilder/json2xml.js
@@ -30,7 +30,8 @@ const defaultOptions = {
     { regex: new RegExp("\"", "g"), val: "&quot;" }
   ],
   processEntities: true,
-  stopNodes: []
+  stopNodes: [],
+  transformTagName: false,
 };
 
 function Builder(options) {

--- a/src/xmlparser/OptionsBuilder.js
+++ b/src/xmlparser/OptionsBuilder.js
@@ -30,7 +30,8 @@ const defaultOptions = {
     processEntities: true,
     htmlEntities: false,
     ignoreDeclaration: false,
-    ignorePiTags: false
+    ignorePiTags: false,
+    transformTagName: false,
 };
    
 const buildOptions = function(options) {

--- a/src/xmlparser/OrderedObjParser.js
+++ b/src/xmlparser/OrderedObjParser.js
@@ -193,6 +193,10 @@ const parseXml = function(xmlData) {
           }
         }
 
+        if(this.options.transformTagName) {
+          tagName = this.options.transformTagName(tagName);
+        }
+
         if(currentNode){
           textData = this.saveTextToParentTag(textData, currentNode, jPath);
         }
@@ -257,12 +261,15 @@ const parseXml = function(xmlData) {
         
         i = closeIndex + 2;
       }else {//Opening tag
-       
         let result = readTagExp(xmlData,i, this. options.removeNSPrefix);
         let tagName= result.tagName;
         let tagExp = result.tagExp;
         let attrExpPresent = result.attrExpPresent;
         let closeIndex = result.closeIndex;
+
+        if (this.options.transformTagName) {
+          tagName = this.options.transformTagName(tagName);
+        }
         
         //save text as child node
         if (currentNode && textData) {
@@ -321,6 +328,10 @@ const parseXml = function(xmlData) {
               tagExp = tagName;
             }else{
               tagExp = tagExp.substr(0, tagExp.length - 1);
+            }
+            
+            if(this.options.transformTagName) {
+              tagName = this.options.transformTagName(tagName);
             }
 
             const childNode = new xmlNode(tagName);


### PR DESCRIPTION
# Purpose / Goal
Add an option to transform tag names in output of `.parse`. Option name is:

```
transformTagName: false | (tagName: string) => string;
```

Pasting the test here because it's a great sample of what this PR does:

```
const xmlData = `<?xml version='1.0'?>
  <root>
    <person>Person 1</person>
    <Person>Person 2</Person>
    <PERSON>Person 3</PERSON>
    <person>Person 4</person>
  </root>
`;

const parser = new XMLParser({
    ignoreDeclaration: true,
    transformTagName: (tagName) => tagName.toLowerCase()
});
let result = parser.parse(xmlData);

const expected = {
    "root": {
        "person": [
            "Person 1",
            "Person 2",
            "Person 3",
            "Person 4"
        ]
    }
};

expect(result).toEqual(expected);```

# Type
Please mention the type of PR
<!-- choose one by changing [ ] to [x] -->
* [ ]Bug Fix
* [ ]Refactoring / Technology upgrade
* [x]New Feature

