### PR TITLE
Update CodeMirror CDN Links in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,10 +18,16 @@
         <link rel="stylesheet" href="static/css/bootstrap.min.css">
         <link rel="stylesheet" href="static/css/prettify.min.css">
         <link rel="stylesheet" href="static/css/jquery-confirm.min.css">
-        <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/6.65.7/codemirror.min.css">
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/6.65.7/codemirror.min.css" 
+                integrity="sha512-uf06llspW44/LZpHzHT6qBOIVODjWtv4MxCricRxkzvopAlSWnTf6hpZTFxuuZcuNE9CBQhqE0Seu1CoRk84nQ==" 
+                crossorigin="anonymous" 
+                referrerpolicy="no-referrer" />
 
         <script src="static/js/jquery-3.2.1.min.js"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/6.65.7/codemirror.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/6.65.7/codemirror.min.js" 
+                integrity="sha512-8RnEqURPUc5aqFEN04aQEiPlSAdE0jlFS/9iGgUyNtwFnSKCXhmB6ZTNl7LnDtDWKabJIASzXrzD0K+LYexU9g==" 
+                crossorigin="anonymous" 
+                referrerpolicy="no-referrer"></script>
         <script src="static/js/bootstrap.min.js"></script>
         <!-- <script src="static/js/prettify.min.js"></script> -->
         <link rel="stylesheet" type="text/css" href="static/css/animate3.5.2.min.css">

--- a/index.html
+++ b/index.html
@@ -18,10 +18,10 @@
         <link rel="stylesheet" href="static/css/bootstrap.min.css">
         <link rel="stylesheet" href="static/css/prettify.min.css">
         <link rel="stylesheet" href="static/css/jquery-confirm.min.css">
-        <link rel="stylesheet" type="text/css" href="https://codemirror.net/lib/codemirror.css">
+        <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/6.65.7/codemirror.min.css">
 
         <script src="static/js/jquery-3.2.1.min.js"></script>
-        <script src="https://codemirror.net/lib/codemirror.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/6.65.7/codemirror.min.js"></script>
         <script src="static/js/bootstrap.min.js"></script>
         <!-- <script src="static/js/prettify.min.js"></script> -->
         <link rel="stylesheet" type="text/css" href="static/css/animate3.5.2.min.css">


### PR DESCRIPTION
TLDR: Demo site was broken due to missing dependency

# Purpose / Goal
Demo site for this package is broken, see e.g. https://github.com/NaturalIntelligence/fast-xml-parser/issues/479

This is due to outdated CDN links for the dependency CodeMirror (giving 404 responses). I replaced the broken links for both javascript and CSS files with links to a working CDN.


# Type
Please mention the type of PR
<!-- choose one by changing [ ] to [x] -->
* [x] Bug Fix
* [ ] Refactoring / Technology upgrade
* [ ] New Feature
