### PR TITLE
fix: Builder tag/attributeValueProcessor types

### DIFF
--- a/src/fxp.d.ts
+++ b/src/fxp.d.ts
@@ -19,7 +19,7 @@ Control how tag value should be parsed. Called only if tag value is not empty
 2. Same value to set parsed value if `parseTagValue: true`.
    */
   tagValueProcessor: (tagName: string, tagValue: string, jPath: string, hasAttributes: boolean, isLeafNode: boolean) => unknown;
-  attributeValueProcessor: (attrName: string, attrValue: string, jPath: string) => string;
+  attributeValueProcessor: (attrName: string, attrValue: string, jPath: string) => unknown;
   numberParseOptions: strnumOptions;
   stopNodes: string[];
   unpairedTags: string[];
@@ -59,8 +59,8 @@ type XmlBuilderOptions = {
   preserveOrder: boolean;
   unpairedTags: string[];
   stopNodes: string[];
-  tagValueProcessor: (name: string, value: string) => string;
-  attributeValueProcessor: (name: string, value: string) => string;
+  tagValueProcessor: (name: string, value: unknown) => string;
+  attributeValueProcessor: (name: string, value: unknown) => string;
   processEntities: boolean;
 };
 type XmlBuilderOptionsOptional = Partial<XmlBuilderOptions>;


### PR DESCRIPTION
# Purpose / Goal
value in should be unknown for both and should align with return type same options on the parser config. 

applies to #489 

this allows the representation of dates and other more complex types in tags and attributes without raising type errors for typescript consumers.






# Type
Please mention the type of PR
<!-- choose one by changing [ ] to [x] -->
* [X ]Bug Fix
* [ ]Refactoring / Technology upgrade
* [ ]New Feature

**Note** : Please ensure that you've read contribution [guidelines](https://github.com/NaturalIntelligence/fast-xml-parser/blob/master/docs/CONTRIBUTING.md) before raising this PR. If your PR is in progress, please prepend `[WIP]` in PR title. Your PR will be reviewed when `[WIP]` will be removed from the PR title.

[Bookmark](https://github.com/NaturalIntelligence/fast-xml-parser/stargazers) this repository for further updates.
