### PR TITLE
Fix entites to entities on XMLValidator doc page

### DIFF
--- a/docs/v4/4.XMLValidator.md
+++ b/docs/v4/4.XMLValidator.md
@@ -49,4 +49,4 @@ const result = XMLValidator.validate( xmlData, {
 });
 ```
 
-[> Next: Entites](./5.Entities.md)
+[> Next: Entities](./5.Entities.md)


### PR DESCRIPTION
# Purpose / Goal
<!-- Please specify here what you're planning to achieve by this pull request and how it can help in regard of this work-space. -->
Fixes a typo of "entites" to "entities"

A separate typo fix from #495 
<!-- If it is a bug fix, please mention the issue number. If there is no issue has been raised but the PR directly then it should follow the template given to raise the issue. Like input, expected output, actual output etc. -->


# Type

<!-- choose one by changing [ ] to [x] -->
* [x]Bug Fix
* [ ]Refactoring / Technology upgrade
* [ ]New Feature
