### PR TITLE
Add support for ignoring < inside stop nodes

### DIFF
--- a/src/fxp.d.ts
+++ b/src/fxp.d.ts
@@ -23,6 +23,7 @@ Control how tag value should be parsed. Called only if tag value is not empty
   attributeValueProcessor: (attrName: string, attrValue: string, jPath: string) => string;
   numberParseOptions: strnumOptions;
   stopNodes: string[];
+  ignoreTagsInNodes: string[];
   unpairedTags: string[];
   alwaysCreateTextNode: boolean;
   isArray: (tagName: string, jPath: string, isLeafNode: boolean, isAttribute: boolean) => boolean;

--- a/src/xmlparser/OptionsBuilder.js
+++ b/src/xmlparser/OptionsBuilder.js
@@ -22,7 +22,8 @@ const defaultOptions = {
     attributeValueProcessor: function(attrName, val) {
       return val;
     },
-    stopNodes: [], //nested tags will not be parsed even for errors
+    stopNodes: [], // nested tags will not be parsed even for errors
+    ignoreTagsInNodes: [], // nested tags will not be parsed even for errors
     alwaysCreateTextNode: false,
     isArray: () => false,
     commentPropName: false,


### PR DESCRIPTION
This is useful for parsing
```
<script>if (a < b) {}</script>
```
since without it, the < is treated as a new tag. This causes the parser to throw an exception when it cannot find a corresponding > to close the tag

# Purpose / Goal
Ideally I'd like to use this library to parse a small subset of HTML, and one of the problems I found with it is that it unfortunately doesn't handle `<` in script tags particularly well.

Currently it treats `<` as the start of an open tag, then looks for a corresponding `>` to close that tag. Sometimes this is a desirable feature to have -- like when parsing `<pre>` tags, the contents should still be valid HTML.

It's just `<script>` that is the odd ball here. This is also why it cannot simply be applied to all `options.stopNodes`, so a new options field had to be added. I went with `options.ignoreTagsInNodes` though I am not attached to that name at all, if you have a better one, please change it :)

# Type
Please mention the type of PR
* [ ]Bug Fix
* [ ]Refactoring / Technology upgrade
* [x]New Feature

[Bookmark](https://github.com/NaturalIntelligence/fast-xml-parser/stargazers) this repository for further updates.
