### PR TITLE
Fixed wrong example code for using the validator

### DIFF
--- a/docs/v4/4.XMLValidator.md
+++ b/docs/v4/4.XMLValidator.md
@@ -2,9 +2,9 @@ XMLParser uses XMLValidator on demand.
 
 ```js
 const {XMLParser} = require("fast-xml-parser");
+const parser = new XMLParser(options);
 try{
-    const parser = new XMLParser(options, true);
-    let result = parser.parse(XMLdata);
+    let result = parser.parse(XMLdata, true);
 }catch(err){
     //:
 }
@@ -24,11 +24,11 @@ const result = XMLValidator.validate(xmlData, {
 
 ```js
 {
-  err: { 
+  err: {
     code: string;
     msg: string,
     line: number,
-    col: number 
+    col: number
   };
 };
 ```


### PR DESCRIPTION
# Purpose / Goal
Fixes an error in the example code, where the boolean parameter to enable validation needs to be specified on the `parse` function, not on the constructor of the `XMLParser`.
I also moved the constructor out of the try/catch block, to easier indicate where the error will be thrown.


# Type
* [x]Bug Fix
* [ ]Refactoring / Technology upgrade
* [ ]New Feature
