### PR TITLE
Add transformAttributeName to transform the attribute name upon parsing

### DIFF
--- a/docs/v4/2.XMLparseOptions.md
+++ b/docs/v4/2.XMLparseOptions.md
@@ -817,6 +817,14 @@ Output
 transformTagName: (tagName) => tagName.toLowerCase()
 ```
 
+## transformAttributeName
+
+`transformAttributeName` property function let you modify the name of attribute
+
+```js
+transformAttributeName: (attributeName) => attributeName.toLowerCase()
+```
+
 ## trimValues
 Remove surrounding whitespace from tag or attribute value.
 

--- a/spec/transform_attributes_spec.js
+++ b/spec/transform_attributes_spec.js
@@ -1,0 +1,39 @@
+"use strict";
+
+const {XMLParser} = require("../src/fxp");
+
+describe("XMLParsers", function() {
+    it("should transform attribute names", function() {
+        const xmlData = `<?xml version='1.0'?>
+          <root>
+            <person title="1">Person 1</person>
+            <person tITle="2">Person 2</Person>
+            <person hello:TItle="3">Person 3</PERSON>
+            <person hElLO:TITLE="4">Person 4</person>
+          </root>
+        `;
+
+        const parser = new XMLParser({
+            ignoreAttributes: false,
+            ignoreDeclaration: true,
+            attributeNamePrefix: "",
+            attributesGroupName: "attributes",
+            transformTagName: (tag) => tag.toLowerCase(),
+            transformAttributeName: (attr) => attr.toLowerCase()
+        });
+        let result = parser.parse(xmlData);
+
+        const expected = {
+            "root": {
+                "person": [
+                    { attributes: { title: "1" }, "#text": "Person 1" },
+                    { attributes: { title: "2" }, "#text": "Person 2" },
+                    { attributes: { "hello:title": "3" }, "#text": "Person 3" },
+                    { attributes: { "hello:title": "4" }, "#text": "Person 4" }
+                ]
+            }
+        };
+
+        expect(result).toEqual(expected);
+    });
+});

--- a/src/fxp.d.ts
+++ b/src/fxp.d.ts
@@ -31,6 +31,7 @@ Control how tag value should be parsed. Called only if tag value is not empty
   ignoreDeclaration: boolean;
   ignorePiTags: boolean;
   transformTagName: ((tagName: string) => string) | false;
+  transformAttributeName: ((attributeName: string) => string) | false;
 };
 type strnumOptions = {
   hex: boolean;

--- a/src/xmlbuilder/json2xml.js
+++ b/src/xmlbuilder/json2xml.js
@@ -32,6 +32,7 @@ const defaultOptions = {
   processEntities: true,
   stopNodes: [],
   transformTagName: false,
+  transformAttributeName: false,
 };
 
 function Builder(options) {

--- a/src/xmlparser/OptionsBuilder.js
+++ b/src/xmlparser/OptionsBuilder.js
@@ -32,6 +32,7 @@ const defaultOptions = {
     ignoreDeclaration: false,
     ignorePiTags: false,
     transformTagName: false,
+    transformAttributeName: false,
 };
    
 const buildOptions = function(options) {

--- a/src/xmlparser/OrderedObjParser.js
+++ b/src/xmlparser/OrderedObjParser.js
@@ -132,8 +132,11 @@ function buildAttributesMap(attrStr, jPath) {
     for (let i = 0; i < len; i++) {
       const attrName = this.resolveNameSpace(matches[i][1]);
       let oldVal = matches[i][4];
-      const aName = this.options.attributeNamePrefix + attrName;
+      let aName = this.options.attributeNamePrefix + attrName;
       if (attrName.length) {
+        if (this.options.transformAttributeName) {
+          aName = this.options.transformAttributeName(aName);
+        }
         if (oldVal !== undefined) {
           if (this.options.trimValues) {
             oldVal = oldVal.trim();


### PR DESCRIPTION
# Purpose / Goal
In my previous PR I added `transformTagName` https://github.com/NaturalIntelligence/fast-xml-parser/pull/469 To keep it consistent I've added a `transformAttributeName` with the same function and signature.

# Type
Please mention the type of PR
<!-- choose one by changing [ ] to [x] -->
* [ ]Bug Fix
* [ ]Refactoring / Technology upgrade
* [x]New Feature

Also included documentation and updated type definitions.

Example:

```js
const parser = new XMLParser({
  transformAttributeName: (attr) => attr.toLowerCase()
});
let result = parser.parse(xmlData);
```

