### PR TITLE
Only set textNodeName, build xml is error

### DIFF
--- a/src/xmlbuilder/json2xml.js
+++ b/src/xmlbuilder/json2xml.js
@@ -239,7 +239,7 @@ function indentate(level) {
 }
 
 function isAttribute(name /*, options*/) {
-  if (name.startsWith(this.options.attributeNamePrefix)) {
+  if (name.startsWith(this.options.attributeNamePrefix) && name !== this.options.textNodeName) {
     return name.substr(this.attrPrefixLen);
   } else {
     return false;


### PR DESCRIPTION
# Purpose / Goal
Only set textNodeName, and attributeNamePrefix is empty string, build result is error.

Example：
```js
const schema_obj = {
      field: {
        values: {
          value: {
            '#text': 10061001,
            size: '5',
          },
        },
        id: 'skuCombineContent',
        type: 'multiInput',
      },
    };

    const parse_options = {
      ignoreAttributes: false,
      attributeNamePrefix: '',
      textNodeName: '#text',
    };
    const builder = new XMLBuilder(parse_options);
    const schema_xml = builder.build(schema_obj);
```

# Type
Please mention the type of PR
<!-- choose one by changing [ ] to [x] -->
* [x]Bug Fix
* [ ]Refactoring / Technology upgrade
* [ ]New Feature
