### PR TITLE
refactor(types): allow to omit options when creating a XMLBuilder instance

### DIFF
--- a/src/fxp.d.ts
+++ b/src/fxp.d.ts
@@ -94,6 +94,6 @@ export class XMLValidator{
   static validate(  xmlData: string,  options?: validationOptionsOptional): true | ValidationError;
 }
 export class XMLBuilder {
-  constructor(options: XmlBuilderOptionsOptional);
+  constructor(options?: XmlBuilderOptionsOptional);
   build(jObj: any): any;
 }


### PR DESCRIPTION


# Purpose / Goal
<!-- Please specify here what you're planning to achieve by this pull request and how it can help in regard of this work-space. -->

Allow to omit options when creating a XMLBuilder instance

The code allows to pass undefined for options.

<!-- If it is a bug fix, please mention the issue number. If there is no issue has been raised but the PR directly then it should follow the template given to raise the issue. Like input, expected output, actual output etc. -->


# Type
Please mention the type of PR
<!-- choose one by changing [ ] to [x] -->
* [ ] Bug Fix
* [x] Refactoring / Technology upgrade
* [ ] New Feature

**Note** : Please ensure that you've read contribution [guidelines](https://github.com/NaturalIntelligence/fast-xml-parser/blob/master/docs/CONTRIBUTING.md) before raising this PR. If your PR is in progress, please prepend `[WIP]` in PR title. Your PR will be reviewed when `[WIP]` will be removed from the PR title.

[Bookmark](https://github.com/NaturalIntelligence/fast-xml-parser/stargazers) this repository for further updates.
