### PR TITLE
IsArray option isn't parsing tags with 0 as value correctly #490

### DIFF
--- a/spec/arrayMode_spec.js
+++ b/spec/arrayMode_spec.js
@@ -175,6 +175,37 @@ describe("XMLParser with arrayMode enabled", function () {
         expect(result).toEqual(expected);
     });
 
+    it("should parse leaf tags with zero or false value correctly in arrayMode", function () {
+        const xmlDataExample = `
+            <report>
+                <value>0</value>
+                <isNew>false</isNew>
+                <isReport>true</isReport>
+            </report>`
+
+        const expected = {
+            "report": 
+                [
+                    {
+                        "value": 0,
+                        "isNew": false,
+                        "isReport": true
+                    }
+                ]
+        };
+
+        const options = {
+            ignoreAttributes: false,
+            isArray: (tagName, jpath, isLeafNode, isAttribute) => { 
+                if(!isLeafNode) return true;
+              }
+        }
+        const parser = new XMLParser(options);
+        const result = parser.parse(xmlDataExample);
+        // console.log(JSON.stringify(result,null,4));
+        expect(result).toEqual(expected);
+    });
+
     it("should parse only attributes as Array if set", function () {
 
         const expected = {

--- a/src/xmlparser/node2json.js
+++ b/src/xmlparser/node2json.js
@@ -94,8 +94,20 @@ function assignAttributes(obj, attrMap, jpath, options){
 }
 
 function isLeafTag(obj, options){
+  const { textNodeName } = options;
   const propCount = Object.keys(obj).length;
-  if( propCount === 0 || (propCount === 1 && obj[options.textNodeName]) ) return true;
+  
+  if (propCount === 0) {
+    return true;
+  }
+
+  if (
+    propCount === 1 &&
+    (obj[textNodeName] || typeof obj[textNodeName] === "boolean" || obj[textNodeName] === 0)
+  ) {
+    return true;
+  }
+
   return false;
 }
 exports.prettify = prettify;


### PR DESCRIPTION
# Purpose / Goal
This is fix for isArray option isn't parsing tags with 0 as value correctly. This only affected when we are parsing tags, not attributes.

The problem is that `obj[options.textNodeName]` is checking the value exist, but if it `false` or `0` it will fail the test.
So you can try to fix it to test it also for boolean type or zero.

The opened issue is #490 


# Type
Please mention the type of PR
<!-- choose one by changing [ ] to [x] -->
* [x]Bug Fix
* [ ]Refactoring / Technology upgrade
* [ ]New Feature


