### PR TITLE
xmlBuilder: introduce initial indentation level option

### DIFF
--- a/docs/v4/3.XMLBuilder.md
+++ b/docs/v4/3.XMLBuilder.md
@@ -175,6 +175,43 @@ Don't consider attributes while building XML. Other attributes related propertie
 ## indentBy
 Applicable only if `format:true` is set.
 
+## initialIndentationLevel
+Applicable only if `format:true` is set.
+
+Allows you to specify initial indentation level for the builder, with default value being `0`.
+
+Example of setting `initialIndentationLevel` option to custom value and building XML:
+
+```
+const data = {
+    ['trans-unit']: {
+        source: 'source string',
+        target: 'target string',
+    },
+};
+
+const options = {
+    format: true,
+    initialIndentationLevel: 1,
+};
+
+const builder = new XMLBuilder(options);
+const result = builder.build(data);
+
+console.log(result);
+```
+
+Output:
+
+```
+  <trans-unit>
+    <source>source string</source>
+    <target>target string</target>
+  </trans-unit>
+```
+
+Giving us prefixed xml document by one indentation level.
+
 ## preserveOrder
 When you parse a XML using XMLParser with `preserveOrder: true`, the result JS object has different structure. So parse that structure in original XML, you should set the same option while building the XML from that js object.
 

--- a/spec/j2x_spec.js
+++ b/spec/j2x_spec.js
@@ -483,4 +483,53 @@ describe("XMLBuilder", function() {
         expect(result).toEqual(expected);
     });
 
+    it('should start indentation from 0 level by default', function() {
+      const data = {
+        ['trans-unit']: {
+          source: 'source string',
+          target: 'target string',
+        },
+      };
+
+      const options = {
+        format: true,
+      };
+
+      const builder = new XMLBuilder(options);
+      const result = builder.build(data);
+
+      const expected =
+        '<trans-unit>\n' +
+        '  <source>source string</source>\n' +
+        '  <target>target string</target>\n' +
+        '</trans-unit>\n';
+
+      expect(result).toEqual(expected);
+    });
+
+    it('should start indentation from specified level', function() {
+      const data = {
+        ['trans-unit']: {
+          source: 'source string',
+          target: 'target string',
+        },
+      };
+
+      const options = {
+        format: true,
+        initialIndentationLevel: 1,
+      };
+
+      const builder = new XMLBuilder(options);
+      const result = builder.build(data);
+
+      const expected =
+        '  <trans-unit>\n' +
+        '    <source>source string</source>\n' +
+        '    <target>target string</target>\n' +
+        '  </trans-unit>\n';
+
+      expect(result).toEqual(expected);
+    });
+
 });

--- a/src/fxp.d.ts
+++ b/src/fxp.d.ts
@@ -63,6 +63,7 @@ type XmlBuilderOptions = {
   commentPropName: false | string;
   format: boolean;
   indentBy: string;
+  initialIndentationLevel: number;
   arrayNodeName: string;
   suppressEmptyNode: boolean;
   suppressUnpairedNode: boolean;

--- a/src/xmlbuilder/json2xml.js
+++ b/src/xmlbuilder/json2xml.js
@@ -10,6 +10,7 @@ const defaultOptions = {
   cdataPropName: false,
   format: false,
   indentBy: '  ',
+  initialIndentationLevel: 0,
   suppressEmptyNode: false,
   suppressUnpairedNode: true,
   suppressBooleanAttributes: true,
@@ -33,7 +34,7 @@ const defaultOptions = {
   stopNodes: [],
   // transformTagName: false,
   // transformAttributeName: false,
-  oneListGroup: false
+  oneListGroup: false,
 };
 
 function Builder(options) {
@@ -71,7 +72,7 @@ Builder.prototype.build = function(jObj) {
         [this.options.arrayNodeName] : jObj
       }
     }
-    return this.j2x(jObj, 0).val;
+    return this.j2x(jObj, this.options.initialIndentationLevel).val;
   }
 };
 


### PR DESCRIPTION
# Purpose / Goal

Introduce new option `initialIndentationLevel` and initialize `builder` with it instead of the literal value `0`.

The option `initialIndentationLevel` is going to default to `0` so that default behaviour will be preserved.

Yet will allow to start generating xml document starting from the specified indentation level.

I explain the reasoning behind introducing this feature extensively in the #565

Closes: #565

# Type

* [ ] Bug Fix
* [ ] Refactoring / Technology upgrade
* [x] New Feature
