### PR TITLE
Fix character reference parsing

### DIFF
--- a/spec/entities_spec.js
+++ b/spec/entities_spec.js
@@ -46,6 +46,34 @@ describe("XMLParser Entities", function() {
         expect(result).toEqual(expected);
     });
 
+    it("should parse different entity character reference variants", function() {
+        const xmlData = `<?xml version="1.0"?>
+            <tests>
+              <test>&lt;</test>
+              <test>&#60;</test>
+              <test>&#060;</test>
+              <test>&#0060;</test>
+              <test>&#x3C;</test>
+              <test>&#x03C;</test>
+              <test>&#x003C;</test>
+              <test>&#x3c;</test>
+              <test>&#x03c;</test>
+              <test>&#x003c;</test>
+            </tests>`;
+
+        const expected = {
+            "?xml": "",
+            "tests": {
+                "test": ["<", "<", "<", "<", "<", "<", "<", "<", "<", "<"]
+            }
+        };
+
+        const parser = new XMLParser();
+        let result = parser.parse(xmlData, true);
+
+        expect(result).toEqual(expected);
+    });
+
     it("should parse XML with DOCTYPE without internal DTD", function() {
         const xmlData = "<?xml version='1.0' standalone='no'?><!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\" \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\" ><svg><metadata>test</metadata></svg>";
         const expected = {

--- a/src/xmlparser/OrderedObjParser.js
+++ b/src/xmlparser/OrderedObjParser.js
@@ -20,26 +20,26 @@ class OrderedObjParser{
     this.tagsNodeStack = [];
     this.docTypeEntities = {};
     this.lastEntities = {
-      "apos" : { regex: /&(apos|#39|#x27);/g, val : "'"},
-      "gt" : { regex: /&(gt|#62|#x3E);/g, val : ">"},
-      "lt" : { regex: /&(lt|#60|#x3C);/g, val : "<"},
-      "quot" : { regex: /&(quot|#34|#x22);/g, val : "\""},
+      "apos" : { regex: /&(apos|#0*39|#x0*27);/gi, val : "'"},
+      "gt" : { regex: /&(gt|#0*62|#x0*3E);/gi, val : ">"},
+      "lt" : { regex: /&(lt|#0*60|#x0*3C);/gi, val : "<"},
+      "quot" : { regex: /&(quot|#0*34|#x0*22);/gi, val : "\""},
     };
-    this.ampEntity = { regex: /&(amp|#38|#x26);/g, val : "&"};
+    this.ampEntity = { regex: /&(amp|#0*38|#x0*26);/gi, val : "&"};
     this.htmlEntities = {
-      "space": { regex: /&(nbsp|#160);/g, val: " " },
-      // "lt" : { regex: /&(lt|#60);/g, val: "<" },
-      // "gt" : { regex: /&(gt|#62);/g, val: ">" },
-      // "amp" : { regex: /&(amp|#38);/g, val: "&" },
-      // "quot" : { regex: /&(quot|#34);/g, val: "\"" },
-      // "apos" : { regex: /&(apos|#39);/g, val: "'" },
-      "cent" : { regex: /&(cent|#162);/g, val: "¢" },
-      "pound" : { regex: /&(pound|#163);/g, val: "£" },
-      "yen" : { regex: /&(yen|#165);/g, val: "¥" },
-      "euro" : { regex: /&(euro|#8364);/g, val: "€" },
-      "copyright" : { regex: /&(copy|#169);/g, val: "©" },
-      "reg" : { regex: /&(reg|#174);/g, val: "®" },
-      "inr" : { regex: /&(inr|#8377);/g, val: "₹" },
+      "space": { regex: /&(nbsp|#0*160);/gi, val: " " },
+      // "lt" : { regex: /&(lt|#0*60);/gi, val: "<" },
+      // "gt" : { regex: /&(gt|#0*62);/gi, val: ">" },
+      // "amp" : { regex: /&(amp|#0*38);/gi, val: "&" },
+      // "quot" : { regex: /&(quot|#0*34);/gi, val: "\"" },
+      // "apos" : { regex: /&(apos|#0*39);/gi, val: "'" },
+      "cent" : { regex: /&(cent|#0*162);/gi, val: "¢" },
+      "pound" : { regex: /&(pound|#0*163);/gi, val: "£" },
+      "yen" : { regex: /&(yen|#0*165);/gi, val: "¥" },
+      "euro" : { regex: /&(euro|#0*8364);/gi, val: "€" },
+      "copyright" : { regex: /&(copy|#0*169);/gi, val: "©" },
+      "reg" : { regex: /&(reg|#0*174);/gi, val: "®" },
+      "inr" : { regex: /&(inr|#0*8377);/gi, val: "₹" },
     };
     this.addExternalEntities = addExternalEntities;
     this.parseXml = parseXml;


### PR DESCRIPTION
Ignore leading zeros and case-insensitive hexadecimal characters.

# Purpose / Goal
<!-- Please specify here what you're planning to achieve by this pull request and how it can help in regard of this work-space. -->

<!-- If it is a bug fix, please mention the issue number. If there is no issue has been raised but the PR directly then it should follow the template given to raise the issue. Like input, expected output, actual output etc. -->
Fixes: https://github.com/NaturalIntelligence/fast-xml-parser/issues/568

# Type
Please mention the type of PR
<!-- choose one by changing [ ] to [x] -->
* [x] Bug Fix
* [ ] Refactoring / Technology upgrade
* [ ] New Feature

**Note** : Please ensure that you've read contribution [guidelines](https://github.com/NaturalIntelligence/fast-xml-parser/blob/master/docs/CONTRIBUTING.md) before raising this PR. If your PR is in progress, please prepend `[WIP]` in PR title. Your PR will be reviewed when `[WIP]` will be removed from the PR title.

[Bookmark](https://github.com/NaturalIntelligence/fast-xml-parser/stargazers) this repository for further updates.

# Benchmark

on master c7b3cea4ead020c21d39e135a50348208829e971:
```
$ node benchmark/XmlParser.js
Running Suite: XML Parser benchmark
fxp v3 : 104492.65920369806 requests/second
fxp : 71740.31616855874 requests/second
fxp - preserve order : 79167.16811125632 requests/second
xmlbuilder2 : 30097.740319390698 requests/second
xml2js  : 19269.565779616878 requests/second

$ node benchmark/XmlBuilder.js
Running Suite: XML Builder benchmark
fxp : 115721.94119323186 requests/second
fxp - preserve order : 254535096.4923456 requests/second
xml2js  : 30245.690942021945 requests/second
```

on PR branch 7ffae077283a5b88ca9ed3fa864fd403c1d22b22:
```
$  node benchmark/XmlParser.js
Running Suite: XML Parser benchmark
fxp v3 : 104906.50130850698 requests/second
fxp : 70241.16491572408 requests/second
fxp - preserve order : 77212.26547824622 requests/second
xmlbuilder2 : 30320.162156061833 requests/second
xml2js  : 19072.050992656794 requests/second

$ node benchmark/XmlBuilder.js
Running Suite: XML Builder benchmark
fxp : 114569.05961947251 requests/second
fxp - preserve order : 249648275.08603555 requests/second
xml2js  : 30008.326170982098 requests/second
```