### PR TITLE
Parser must skip unopened closing tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Note: If you find missing information about particular minor version, that version must have been changed without any functional change in this library.
 
 **4.2.3 / 2023-05-23**
-* fix #573: unopened closing tags should be ignored instead of throwing "*Cannot read properties of undefined*" exception.
+* fix: Unopened closing tags should be ignored by XMLParser instead of throwing "*Cannot read properties of undefined*" exception.
 
 **4.2.2 / 2023-04-18**
 * fix #562: fix unpaired tag when it comes in last of a nested tag. Also throw error when unpaired tag is used as closing tag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Note: If you find missing information about particular minor version, that version must have been changed without any functional change in this library.
 
+**4.2.3 / 2023-05-23**
+* fix #573: unopened closing tags should be ignored instead of throwing "*Cannot read properties of undefined*" exception.
+
 **4.2.2 / 2023-04-18**
 * fix #562: fix unpaired tag when it comes in last of a nested tag. Also throw error when unpaired tag is used as closing tag
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fast-xml-parser",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "description": "Validate XML, Parse XML, Build XML without C/C++ based libraries",
   "main": "./src/fxp.js",
   "scripts": {

--- a/spec/xmlParser_spec.js
+++ b/spec/xmlParser_spec.js
@@ -1066,4 +1066,36 @@ describe("XMLParser", function() {
   
       expect(result).toEqual(expected);
     });
+
+    it("should ignore closing tags without an opening tag", function() {
+        const xmlData = `<rootNode>
+                            <parentTag attr='my attr'>
+                                <childTag>Hello</childTag>
+                            </parentTag>
+                            <parentTag attr='my attr'>
+                                </childTag> <!-- This is a closing tag without an opening tag. Thus parsing should ignore such case and move forward -->
+                            </parentTag>
+                        </rootNode>`;    
+        const options = {            
+            ignoreAttributes: false,
+            preserveOrder: false,
+            alwaysCreateTextNode: false
+        };
+        const expected = {
+            "rootNode": {
+                "parentTag": [
+                    {
+                        "childTag": "Hello",
+                        "@_attr": "my attr"
+                    },
+                    {
+                        "@_attr": "my attr"
+                    }
+                ]
+            }
+        };
+        const parser = new XMLParser(options);
+        let result = parser.parse(xmlData);
+        expect(result).toEqual(expected);
+    });
 });

--- a/spec/xmlParser_spec.js
+++ b/spec/xmlParser_spec.js
@@ -1098,4 +1098,45 @@ describe("XMLParser", function() {
         let result = parser.parse(xmlData);
         expect(result).toEqual(expected);
     });
+
+    it("should ignore closing tags without an opening tag", function() {
+        const xmlData = `<rootNode>
+                            <parentTag attr='my attr'>
+                                <childTag>Hello</childTag>
+                            </parentTag>
+                            <parentTag attr='my attr'>
+                                </childTag> <!-- unopened closing tag -->
+                                </childTag> <!-- unopened closing tag -->
+                            </parentTag>
+                            </parentTag> <!-- unopened closing tag -->
+                            <parentTag attr='my attr'>
+                                <childTag>World</childTag>
+                            </parentTag>
+                        </rootNode>`;
+        const options = {            
+            ignoreAttributes: false,
+            preserveOrder: false,
+            alwaysCreateTextNode: false
+        };
+        const expected = {
+            "rootNode": {
+                "parentTag": [
+                    {
+                        "childTag": "Hello",
+                        "@_attr": "my attr"
+                    },
+                    {
+                        "@_attr": "my attr"
+                    },
+                    {
+                        "childTag": "World",
+                        "@_attr": "my attr"
+                    }
+                ]
+            }
+        };
+        const parser = new XMLParser(options);
+        let result = parser.parse(xmlData);
+        expect(result).toEqual(expected);
+    });
 });

--- a/spec/xmlParser_spec.js
+++ b/spec/xmlParser_spec.js
@@ -1073,38 +1073,6 @@ describe("XMLParser", function() {
                                 <childTag>Hello</childTag>
                             </parentTag>
                             <parentTag attr='my attr'>
-                                </childTag> <!-- This is a closing tag without an opening tag. Thus parsing should ignore such case and move forward -->
-                            </parentTag>
-                        </rootNode>`;    
-        const options = {            
-            ignoreAttributes: false,
-            preserveOrder: false,
-            alwaysCreateTextNode: false
-        };
-        const expected = {
-            "rootNode": {
-                "parentTag": [
-                    {
-                        "childTag": "Hello",
-                        "@_attr": "my attr"
-                    },
-                    {
-                        "@_attr": "my attr"
-                    }
-                ]
-            }
-        };
-        const parser = new XMLParser(options);
-        let result = parser.parse(xmlData);
-        expect(result).toEqual(expected);
-    });
-
-    it("should ignore closing tags without an opening tag", function() {
-        const xmlData = `<rootNode>
-                            <parentTag attr='my attr'>
-                                <childTag>Hello</childTag>
-                            </parentTag>
-                            <parentTag attr='my attr'>
                                 </childTag> <!-- unopened closing tag -->
                                 </childTag> <!-- unopened closing tag -->
                             </parentTag>

--- a/src/xmlparser/OrderedObjParser.js
+++ b/src/xmlparser/OrderedObjParser.js
@@ -220,7 +220,7 @@ const parseXml = function(xmlData) {
         }
         jPath = jPath.substring(0, propIndex);
 
-        currentNode = this.tagsNodeStack.pop();//avoid recursion, set the parent tag scope
+        currentNode = this.tagsNodeStack.length ? this.tagsNodeStack.pop() : currentNode;//avoid recursion, set the parent tag scope
         textData = "";
         i = closeIndex;
       } else if( xmlData[i+1] === '?') {

--- a/src/xmlparser/OrderedObjParser.js
+++ b/src/xmlparser/OrderedObjParser.js
@@ -207,20 +207,23 @@ const parseXml = function(xmlData) {
         }
 
         //check if last tag of nested tag was unpaired tag
-        const lastTagName = jPath.substring(jPath.lastIndexOf(".")+1);
+        const lastTagName = jPath.substring(jPath.lastIndexOf("|")+1);
         if(tagName && this.options.unpairedTags.indexOf(tagName) !== -1 ){
           throw new Error(`Unpaired tag can not be used as closing tag: </${tagName}>`);
         }
         let propIndex = 0
         if(lastTagName && this.options.unpairedTags.indexOf(lastTagName) !== -1 ){
-          propIndex = jPath.lastIndexOf('.', jPath.lastIndexOf('.')-1)
+          propIndex = jPath.lastIndexOf('|', jPath.lastIndexOf('|')-1)
           this.tagsNodeStack.pop();
         }else{
-          propIndex = jPath.lastIndexOf(".");
-        }
-        jPath = jPath.substring(0, propIndex);
+          propIndex = jPath.lastIndexOf("|");
+        }        
+        if(lastTagName === tagName) {
+          //update path and pop out node only when the closing tag matches with opening tag. This condition will thus ignore unopened closing tags.
+          jPath = jPath.substring(0, propIndex);
 
-        currentNode = this.tagsNodeStack.length ? this.tagsNodeStack.pop() : currentNode;//avoid recursion, set the parent tag scope
+          currentNode = this.tagsNodeStack.pop();//avoid recursion, set the parent tag scope
+        }
         textData = "";
         i = closeIndex;
       } else if( xmlData[i+1] === '?') {
@@ -300,10 +303,10 @@ const parseXml = function(xmlData) {
         const lastTag = currentNode;
         if(lastTag && this.options.unpairedTags.indexOf(lastTag.tagname) !== -1 ){
           currentNode = this.tagsNodeStack.pop();
-          jPath = jPath.substring(0, jPath.lastIndexOf("."));
+          jPath = jPath.substring(0, jPath.lastIndexOf("|"));
         }
         if(tagName !== xmlObj.tagname){
-          jPath += jPath ? "." + tagName : tagName;
+          jPath += jPath ? "|" + tagName : tagName;
         }
         if (this.isItStopNode(this.options.stopNodes, jPath, tagName)) { //TODO: namespace
           let tagContent = "";
@@ -332,7 +335,7 @@ const parseXml = function(xmlData) {
             tagContent = this.parseTextData(tagContent, tagName, jPath, true, attrExpPresent, true, true);
           }
           
-          jPath = jPath.substr(0, jPath.lastIndexOf("."));
+          jPath = jPath.substr(0, jPath.lastIndexOf("|"));
           childNode.add(this.options.textNodeName, tagContent);
           
           this.addChild(currentNode, childNode, jPath)
@@ -355,7 +358,7 @@ const parseXml = function(xmlData) {
               childNode[":@"] = this.buildAttributesMap(tagExp, jPath, tagName);
             }
             this.addChild(currentNode, childNode, jPath)
-            jPath = jPath.substr(0, jPath.lastIndexOf("."));
+            jPath = jPath.substr(0, jPath.lastIndexOf("|"));
           }
     //opening tag
           else{


### PR DESCRIPTION
# Purpose / Goal
When an xml/html has closing tags without opening tags, then the parser should skip it and continue it's parsing rather than blocking execution by throwing exception.

## Code
```
new XMLParser({ ignoreAttributes: false })
.parse('<rootNode>
<parentTag attr='my attr 1'>
    <childTag>Hello</childTag>
</parentTag>
<parentTag attr='my attr 2'>
    </childTag> <!--Unopned Closing Tag-->
    </childTag> <!--Unopned Closing Tag-->
</parentTag>
</parentTag> <!--Unopned Closing Tag-->
<parentTag attr='my attr 3'>
    <childTag>World</childTag>
</parentTag>
</rootNode>')
```
## Output
`Uncaught TypeError TypeError: Cannot read properties of undefined (reading 'addChild')`

## Expected Output
```
{
    "rootNode": {
        "parentTag": [
            {
                "childTag": "Hello",
                "@_attr": "my attr 1"
            },
            {
                "@_attr": "my attr 2"
            },
            {
                "childTag": "World",
                "@_attr": "my attr 3"
            }
        ]
    }
}
```

## Benchmark
### Before Changes
```
Running Suite: XML Parser benchmark
fxp v3 : 84779.33893486593 requests/second
fxp : 51112.199678104116 requests/second
fxp - preserve order : 50404.274179940876 requests/second       
xmlbuilder2 : 19283.905598973546 requests/second
xml2js  : 13955.238383909073 requests/second
```
### After Changes
```
Running Suite: XML Parser benchmark
fxp v3 : 78604.65479491939 requests/second
fxp : 47949.98355614185 requests/second
fxp - preserve order : 51482.93159290693 requests/second
xmlbuilder2 : 20161.459509073473 requests/second
xml2js  : 14325.551131080862 requests/second
```

# Type
Please mention the type of PR
<!-- choose one by changing [ ] to [x] -->
* [x] Bug Fix
* [ ] Refactoring / Technology upgrade
* [ ] New Feature
