### PR TITLE
Change the typedefs and docs for updateTag to match how FXP actually behaves

### DIFF
--- a/docs/v4/2.XMLparseOptions.md
+++ b/docs/v4/2.XMLparseOptions.md
@@ -907,7 +907,11 @@ Output
 **Note**: Unpaired tag can't be used as closing tag e.g. `</unpaired>` is not allowed.
 ## updateTag
 
-This property allow you to change tag name when you send different name, skip a tag from the parsing result when you return false, or to change attributes.
+This method allows you to modify the tag by changing the tag name, modifying its attributes, or completely skip the tag from the parsing result.
+* When a string is returned that will be the new tag name.
+* Returning `false` or `undefined` will skip this tag from the parsing result.
+* Returning `true` will make no changes at all
+
 ```js
 const xmlDataStr = `
     <rootNode>
@@ -928,6 +932,19 @@ const options = {
 };
 const parser = new XMLParser(options);
 const output = parser.parse(xmlDataStr);
+```
+
+Output
+```json
+{
+    "rootNode": {
+        "A": {
+            "#text": "value",
+            "At": "Home"
+        },
+        "At": "Home"
+    }
+}
 ```
 
 [> Next: XmlBuilder](./3.XMLBuilder.md)

--- a/src/fxp.d.ts
+++ b/src/fxp.d.ts
@@ -36,10 +36,12 @@ Control how tag value should be parsed. Called only if tag value is not empty
 Change the tag name when a different name is returned. Skip the tag from parsed result when false is returned. 
 Modify `attrs` object to control attributes for the given tag.
 
-@returns {string} new tag name.
-@returns false to skip the tag
+@returns {string} to change the tag name
+@returns {true} to not make any changes
+@returns {false} to skip the tag from the parsing result
+@returns {undefined} to skip the tag from the parsing result
    */
-  updateTag: (tagName: string, jPath: string, attrs: {[k: string]: string}) =>  string | boolean;
+  updateTag: (tagName: string, jPath: string, attrs: {[k: string]: string}) =>  string | boolean | undefined;
 };
 type strnumOptions = {
   hex: boolean;


### PR DESCRIPTION
# Purpose / Goal
According to the comments in [discussion #576 ](https://github.com/NaturalIntelligence/fast-xml-parser/discussions/576) the `updateTag` method actually allows for the `undefined` return type. This PR makes two simple changes:
* It updates the TypeScript type definitions to match the behavior
* It updates the docs to better describe the behavior and gives an output sample from the example code


# Type
* [ ] Bug Fix
* [ ] Refactoring / Technology upgrade
* [ ] New Feature
* [x] Docs & TypeDefs update

---

## Regarding the typedefs update
Currently returning `undefined` while using typescript will give this error
```
Type '(tagName: string, jPath: string, attrs: { [k: string]: string; }) => false | "A" | undefined' is not assignable to type '(tagName: string, jPath: string, attrs: { [k: string]: string; }) => string | boolean'.
  Type 'false | "A" | undefined' is not assignable to type 'string | boolean'.
    Type 'undefined' is not assignable to type 'string | boolean'.ts(2322)
```
The update the the typedefs will fix this and allow this to happen.

## Regarding the docs update
A note about the example output in the docs that I added.  This is the exact output when I tested it by running the code example given in the docs.  It seems to say that` "At": "Home"` is added as an attribute on the `A` tag, but also ` "At": "Home"` seems to be added as an element.  This seems odd to me but I'm also somewhat new to FXP and I'm not sure if this is intended behavior or not. Regardless though, this is what the output is, and now the docs will give an example of that.


##Regarding returning `undefined`
As far as I can tell when `updateTag` method has `return undefined`, it behaves exactly the same as `return false`. The docs and the typedefs now explicitly mention that.