### PR TITLE
Only set textNodeName, build xml is error

### DIFF
--- a/src/xmlbuilder/json2xml.js
+++ b/src/xmlbuilder/json2xml.js
@@ -239,7 +239,7 @@ function indentate(level) {
 }
 
 function isAttribute(name /*, options*/) {
-  if (name.startsWith(this.options.attributeNamePrefix)) {
+  if (name.startsWith(this.options.attributeNamePrefix) && name !== this.options.textNodeName) {
     return name.substr(this.attrPrefixLen);
   } else {
     return false;


### PR DESCRIPTION
# Purpose / Goal
Only set textNodeName, and attributeNamePrefix is empty string, build result is error.

Example：
```js
const schema_obj = {
      field: {
        values: {
          value: {
            '#text': 10061001,
            size: '5',
          },
        },
        id: 'skuCombineContent',
        type: 'multiInput',
      },
    };

    const parse_options = {
      ignoreAttributes: false,
      attributeNamePrefix: '',
      textNodeName: '#text',
    };
    const builder = new XMLBuilder(parse_options);
    const schema_xml = builder.build(schema_obj);
```

# Type
Please mention the type of PR
<!-- choose one by changing [ ] to [x] -->
* [x]Bug Fix
* [ ]Refactoring / Technology upgrade
* [ ]New Feature


Test code: 
```ts
it('xml build test', async () => {
    const schema_obj = {
      field: {
        values: {
          value: {
            '#text': 10061001,
            size: '5',
          },
        },
        id: 'skuCombineContent',
        name: 'skuProduct',
        type: 'multiInput',
      },
    };

    const parse_options = {
      ignoreAttributes: false,
      attributeNamePrefix: '',
      textNodeName: '#text',
    };
    const builder = new XMLBuilder(parse_options);
    const schema_xml = builder.build(schema_obj);
    console.log(schema_xml);
  });
```
The current code execution results：
```xml
<field id="skuCombineContent" name="skuProduct" type="multiInput"><values><value #text="10061001" size="5"></value></values></field>
```

Modify `isAttribute` in json2xml.js
```js
function isAttribute(name /*, options*/) {
  if (name.startsWith(this.options.attributeNamePrefix) && name !== this.options.textNodeName) {
    return name.substr(this.attrPrefixLen);
  } else {
    return false;
  }
}
```

Get the accurate results：
```xml
 <field id="skuCombineContent" name="skuProduct" type="multiInput"><values><value size="5">10061001</value></values></field>
```