### PR TITLE
fix(types): make `build` and `parse` generic

### DIFF
--- a/src/fxp.d.ts
+++ b/src/fxp.d.ts
@@ -88,9 +88,11 @@ type ValidationError = {
   };
 };
 
+type GenericObject = Record<string, unknown>;
+
 export class XMLParser {
   constructor(options?: X2jOptionsOptional);
-  parse(xmlData: string | Buffer ,validationOptions?: validationOptionsOptional | boolean): any;
+  parse<TValue extends GenericObject = GenericObject>(xmlData: string | Buffer ,validationOptions?: validationOptionsOptional | boolean): TValue;
   /**
    * Add Entity which is not by default supported by this library
    * @param entityIndentifier {string} Eg: 'ent' for &ent;
@@ -104,5 +106,5 @@ export class XMLValidator{
 }
 export class XMLBuilder {
   constructor(options?: XmlBuilderOptionsOptional);
-  build(jObj: any): any;
+  build<TValue extends GenericObject = GenericObject>(jObj: TValue): string;
 }

--- a/src/fxp.d.ts
+++ b/src/fxp.d.ts
@@ -88,11 +88,11 @@ type ValidationError = {
   };
 };
 
-type GenericObject = Record<string, unknown>;
+type GenericObjectOrArray<TValue> = Record<string, unknown> | TValue[];
 
 export class XMLParser {
   constructor(options?: X2jOptionsOptional);
-  parse<TValue extends GenericObject = GenericObject>(xmlData: string | Buffer ,validationOptions?: validationOptionsOptional | boolean): TValue;
+  parse<TObject extends GenericObjectOrArray<unknown> = GenericObjectOrArray<unknown>>(xmlData: string | Buffer ,validationOptions?: validationOptionsOptional | boolean): TObject;
   /**
    * Add Entity which is not by default supported by this library
    * @param entityIndentifier {string} Eg: 'ent' for &ent;
@@ -106,5 +106,5 @@ export class XMLValidator{
 }
 export class XMLBuilder {
   constructor(options?: XmlBuilderOptionsOptional);
-  build<TValue extends GenericObject = GenericObject>(jObj: TValue): string;
+  build<TObject extends GenericObjectOrArray<unknown> = GenericObjectOrArray<unknown>>(jObj: TObject): string;
 }


### PR DESCRIPTION
# Purpose / Goal

This PR improves typing for `build` and `parse` by making both functions generic.

It also fixes the return type of `build`, which should be `string`.

## `parse`

```ts
// Before
const result = xml.parse(data); // `result` is `any`

// After
type ExpectedObject = {
  title: string;
  description: string;
};

const result = xml.parse<ExpectedObject>(data); // `result` is `ExpectedObject`
```

## `build`

```ts
// Before
const xml = builder.build(obj); // `xml` is `any`

// After
const xml = builder.build(obj); // `xml` is `string`
```

# Type
Please mention the type of PR
<!-- choose one by changing [ ] to [x] -->
* [x] Bug Fix
* [ ] Refactoring / Technology upgrade
* [ ] New Feature
