### PR TITLE
Remove trailing slash from jPath for self-closing tags

### DIFF
--- a/spec/updateTag_spec.js
+++ b/spec/updateTag_spec.js
@@ -121,6 +121,8 @@ describe("XMLParser updateTag ", function() {
                 <img width="500" height="500">
             </content>
             <script></script>
+            <lorem/>
+            <ipsum/>
         </body>
     </html>`;
         const expected = {
@@ -167,6 +169,10 @@ describe("XMLParser updateTag ", function() {
                     if(attrs.width > 200 || attrs.height > 200) return false;
                 }else if(tagname === "content"){
                     return "div"
+                }else if(tagname === "lorem") {
+                    return false;
+                }else if(jPath === "html.body.ipsum") {
+                    return false;
                 }
                 return tagname;
             },

--- a/src/xmlparser/OrderedObjParser.js
+++ b/src/xmlparser/OrderedObjParser.js
@@ -341,6 +341,7 @@ const parseXml = function(xmlData) {
           if(tagExp.length > 0 && tagExp.lastIndexOf("/") === tagExp.length - 1){
             if(tagName[tagName.length - 1] === "/"){ //remove trailing '/'
               tagName = tagName.substr(0, tagName.length - 1);
+              jPath = jPath.substr(0, jPath.length - 1);
               tagExp = tagName;
             }else{
               tagExp = tagExp.substr(0, tagExp.length - 1);


### PR DESCRIPTION
# Purpose / Goal
<!-- Please specify here what you're planning to achieve by this pull request and how it can help in regard of this work-space. -->

<!-- If it is a bug fix, please mention the issue number. If there is no issue has been raised but the PR directly then it should follow the template given to raise the issue. Like input, expected output, actual output etc. -->

Fixes #564 

The `jPath` in `updateTag()` callback for self-closing tags contained a trailing slash (like: `root.a/`) which was not intended and could lead to errors if you implemented logic based on the `jPath` and did not take that into account.

I've added removing trailing slash from `jPath` in the same place where it's removed from `tagName`.

# Type
Please mention the type of PR
<!-- choose one by changing [ ] to [x] -->
* [x]Bug Fix
* [ ]Refactoring / Technology upgrade
* [ ]New Feature

