### PR TITLE
Fix stopNodes to work with removeNSPrefix (#607)

### DIFF
--- a/spec/stopNodes_spec.js
+++ b/spec/stopNodes_spec.js
@@ -4,6 +4,57 @@ const { XMLParser, XMLValidator } = require("../src/fxp");
 const he = require("he");
 
 describe("XMLParser StopNodes", function () {
+  it("should support single stopNode with namespace and removeNSPrefix set", function () {
+    const xmlData = `<issue><title>test 1</title><namespace:fix1><p>p 1</p><div class="show">div 1</div></namespace:fix1></issue>`;
+    const expected = {
+      "issue": {
+        "title": "test 1",
+        "fix1": "<p>p 1</p><div class=\"show\">div 1</div>"
+      }
+    };
+
+    const options = {
+      attributeNamePrefix: "",
+      ignoreAttributes: false,
+      parseAttributeValue: true,
+      removeNSPrefix: true,
+      stopNodes: ["issue.fix1"]
+    };
+    const parser = new XMLParser(options);
+    let result = parser.parse(xmlData);
+
+    // console.log(JSON.stringify(result,null,4));
+    expect(result).toEqual(expected);
+
+    result = XMLValidator.validate(xmlData);
+    expect(result).toBe(true);
+  });
+
+  it("should support single stopNode with namespace", function () {
+    const xmlData = `<issue><title>test 1</title><namespace:fix1><p>p 1</p><div class="show">div 1</div></namespace:fix1></issue>`;
+    const expected = {
+      "issue": {
+        "title": "test 1",
+        "namespace:fix1": "<p>p 1</p><div class=\"show\">div 1</div>"
+      }
+    };
+
+    const options = {
+      attributeNamePrefix: "",
+      ignoreAttributes: false,
+      parseAttributeValue: true,
+      stopNodes: ["issue.namespace:fix1"]
+    };
+    const parser = new XMLParser(options);
+    let result = parser.parse(xmlData);
+
+    // console.log(JSON.stringify(result,null,4));
+    expect(result).toEqual(expected);
+
+    result = XMLValidator.validate(xmlData);
+    expect(result).toBe(true);
+  });
+
   it("1a. should support single stopNode", function () {
     const xmlData = `<issue><title>test 1</title><fix1><p>p 1</p><div class="show">div 1</div></fix1></issue>`;
     const expected = {

--- a/src/xmlparser/OrderedObjParser.js
+++ b/src/xmlparser/OrderedObjParser.js
@@ -280,6 +280,7 @@ const parseXml = function(xmlData) {
       }else {//Opening tag
         let result = readTagExp(xmlData,i, this.options.removeNSPrefix);
         let tagName= result.tagName;
+        const rawTagName = result.rawTagName;
         let tagExp = result.tagExp;
         let attrExpPresent = result.attrExpPresent;
         let closeIndex = result.closeIndex;
@@ -305,7 +306,7 @@ const parseXml = function(xmlData) {
         if(tagName !== xmlObj.tagname){
           jPath += jPath ? "." + tagName : tagName;
         }
-        if (this.isItStopNode(this.options.stopNodes, jPath, tagName)) { //TODO: namespace
+        if (this.isItStopNode(this.options.stopNodes, jPath, tagName)) {
           let tagContent = "";
           //self-closing tag
           if(tagExp.length > 0 && tagExp.lastIndexOf("/") === tagExp.length - 1){
@@ -318,8 +319,8 @@ const parseXml = function(xmlData) {
           //normal tag
           else{
             //read until closing tag is found
-            const result = this.readStopNodeData(xmlData, tagName, closeIndex + 1);
-            if(!result) throw new Error(`Unexpected end of ${tagName}`);
+            const result = this.readStopNodeData(xmlData, rawTagName, closeIndex + 1);
+            if(!result) throw new Error(`Unexpected end of ${rawTagName}`);
             i = result.i;
             tagContent = result.tagContent;
           }
@@ -504,6 +505,7 @@ function readTagExp(xmlData,i, removeNSPrefix, closingChar = ">"){
     tagExp = tagExp.substr(separatorIndex + 1);
   }
 
+  const rawTagName = tagName;
   if(removeNSPrefix){
     const colonIndex = tagName.indexOf(":");
     if(colonIndex !== -1){
@@ -517,6 +519,7 @@ function readTagExp(xmlData,i, removeNSPrefix, closingChar = ">"){
     tagExp: tagExp,
     closeIndex: closeIndex,
     attrExpPresent: attrExpPresent,
+    rawTagName: rawTagName,
   }
 }
 /**


### PR DESCRIPTION
# Purpose / Goal
The `stopNodes` option currently doesn't work with the `remoteNSPrefix` option. This pull request fixes that issue and adds tests to demonstrate the fix.

# Type
Please mention the type of PR
<!-- choose one by changing [ ] to [x] -->
* [X] Bug Fix
* [ ] Refactoring / Technology upgrade
* [ ] New Feature
