### PR TITLE
Fix `jObj.hasOwnProperty is not a function`

### DIFF
--- a/src/xmlbuilder/json2xml.js
+++ b/src/xmlbuilder/json2xml.js
@@ -79,7 +79,7 @@ Builder.prototype.j2x = function(jObj, level) {
   let attrStr = '';
   let val = '';
   for (let key in jObj) {
-    if(!jObj.hasOwnProperty(key)) continue;
+    if(!Object.hasOwn(jObj, key)) continue;
     if (typeof jObj[key] === 'undefined') {
       // supress undefined node only if it is not an attribute
       if (this.isAttribute(key)) {

--- a/src/xmlbuilder/json2xml.js
+++ b/src/xmlbuilder/json2xml.js
@@ -79,7 +79,7 @@ Builder.prototype.j2x = function(jObj, level) {
   let attrStr = '';
   let val = '';
   for (let key in jObj) {
-    if(!Object.hasOwn(jObj, key)) continue;
+    if(!Object.prototype.hasOwnProperty.call(jObj, key)) continue;
     if (typeof jObj[key] === 'undefined') {
       // supress undefined node only if it is not an attribute
       if (this.isAttribute(key)) {


### PR DESCRIPTION
# Purpose / Goal
If the given object has `null` prototype instead of `Object`, it throws `jObj.hasOwnProperty` error.
`Object.prototype.hasOwnProperty.call(` should be used instead for this kind of objects.


# Type
Please mention the type of PR
* [x]Bug Fix
* [ ]Refactoring / Technology upgrade
* [ ]New Feature

**Note** : Please ensure that you've read contribution [guidelines](https://github.com/NaturalIntelligence/fast-xml-parser/blob/master/docs/CONTRIBUTING.md) before raising this PR. If your PR is in progress, please prepend `[WIP]` in PR title. Your PR will be reviewed when `[WIP]` will be removed from the PR title.

[Bookmark](https://github.com/NaturalIntelligence/fast-xml-parser/stargazers) this repository for further updates.
