### PR TITLE
Don't escape entities in CDATA sections

### DIFF
--- a/spec/cdata_spec.js
+++ b/spec/cdata_spec.js
@@ -446,4 +446,20 @@ patronymic</person></root>`;
         // console.log(JSON.stringify(result,null,4));
         expect(result).toEqual(expected);
     });
+
+    it("should not process entities in CDATA", function() {
+        const xmlData =`<xml><![CDATA[&lt;text&gt;]]></xml>`;
+
+        const expected = { xml: '&lt;text&gt;' };
+
+        const options = {
+            ignoreAttributes: false,
+        };
+
+        const parser = new XMLParser(options);
+        let result = parser.parse(xmlData);
+
+        // console.log(JSON.stringify(result,null,4));
+        expect(result).toEqual(expected);
+    });
 });

--- a/spec/entities_spec.js
+++ b/spec/entities_spec.js
@@ -27,7 +27,7 @@ describe("XMLParser Entities", function() {
                 "a:b": 2,
                 "a-b:b-a": 2,
                 "a:c": "test&\nтест<\ntest",
-                "a:el": "<a><<a/><b>2</b>]]]]>&a",
+                "a:el": "<a>&lt;<a/>&lt;b&gt;2</b>]]]]>&amp;a",
                 "c:string": {
                     "#text": "&#x441;&#x442;&#x440;&#x430;&#x445;&#x43e;&#x432;&#x430;&#x43d;&#x438;&#x44f;    » &#x43e;&#x442; &#x441;&#x443;&#x43c;&#x43c;&#x44b;     &#x435;&#x433;&#x43e; &#x430;&#x43a;&#x442;&#x438;&#x432;&#x43e;&#x432;",
                     "@_lang": "ru"

--- a/src/xmlparser/OrderedObjParser.js
+++ b/src/xmlparser/OrderedObjParser.js
@@ -265,14 +265,13 @@ const parseXml = function(xmlData) {
 
         textData = this.saveTextToParentTag(textData, currentNode, jPath);
 
+        let val = this.parseTextData(tagExp, currentNode.tagname, jPath, true, false, true, true);
+        if(val == undefined) val = "";
+
         //cdata should be set even if it is 0 length string
         if(this.options.cdataPropName){
-          // let val = this.parseTextData(tagExp, this.options.cdataPropName, jPath + "." + this.options.cdataPropName, true, false, true);
-          // if(!val) val = "";
           currentNode.add(this.options.cdataPropName, [ { [this.options.textNodeName] : tagExp } ]);
         }else{
-          let val = this.parseTextData(tagExp, currentNode.tagname, jPath, true, false, true);
-          if(val == undefined) val = "";
           currentNode.add(this.options.textNodeName, val);
         }
         


### PR DESCRIPTION
# Purpose / Goal
<!-- Please specify here what you're planning to achieve by this pull request and how it can help in regard of this work-space. -->
Changes the parsing of CDATA sections to not escape entities.

In other words:
- Before: `<[CDATA[&amp;]]>` -> `&`
- After: `<[CDATA[&amp;]]>` -> `&amp;`

I also added a new test so that this behavior can be tested on its own.

Please note that I did not attempt to avoid any breaking changes here as the issue suggested, but if it is desired, I would be happy to gate this fix behind a new option.

The contents of a CDATA section will also now be run through `tagValueProcessor` even when the `cdataPropName` option is provided. I am unsure as to if this inconsistency was intentional (the code that would have made it consistent seems to have been commented out a while ago), so if that is considered an unrelated change, I would also be happy to split it out into a separate PR.

<!-- If it is a bug fix, please mention the issue number. If there is no issue has been raised but the PR directly then it should follow the template given to raise the issue. Like input, expected output, actual output etc. -->
Closes #632.

## Performance tests
Before:
```
fxp v3 : 57564.501862728255 requests/second
fxp : 32731.178545462913 requests/second
fxp - preserve order : 35714.0221273455 requests/second
xmlbuilder2 : 15299.516192662688 requests/second
xml2js  : 18881.74875804895 requests/second
```
After:
```
fxp v3 : 57721.92080194106 requests/second
fxp : 36231.444954502214 requests/second
fxp - preserve order : 39372.370501577694 requests/second
xmlbuilder2 : 15294.661359575506 requests/second
xml2js  : 18533.786914067532 requests/second
```

# Type
Please mention the type of PR
<!-- choose one by changing [ ] to [x] -->
* [x] Bug Fix
* [ ] Refactoring / Technology upgrade
* [ ] New Feature