### PR TITLE
Add support for parsing HTML numeric entities

### DIFF
--- a/docs/v4/5.Entities.md
+++ b/docs/v4/5.Entities.md
@@ -132,6 +132,8 @@ Following HTML entities are supported by the parser by default when `htmlEntitie
 | ₹      | Indian Rupee               | `&inr;`       | `&#8377;`        |
 ---
 
+In addition, [numeric character references](https://html.spec.whatwg.org/multipage/syntax.html#syntax-charref) are also supported. Both decimal (`num_dec`) and hexadecimal(`num_hex`).
+
 In future version of FXP, we'll be supporting more features of DOCTYPE such as `ELEMENT`, reading content for an entity from a file etc.
 
 ## External Entities

--- a/spec/entities_spec.js
+++ b/spec/entities_spec.js
@@ -377,6 +377,41 @@ describe("XMLParser Entities", function() {
         expect(result).toEqual(expected);
     });
 
+    
+    it("should parse HTML numeric entities when htmlEntities:true", function() {
+        const xmlData = `
+        <?xml version="1.0" encoding="UTF-8"?>
+        <note>
+            <heading>Bear</heading>
+            <body face="&#x295;&#x2022;&#x1D25;&#x2022;&#x294;">Bears are called B&#228;ren in German!</body>
+        </note> `;
+
+        const expected = {
+            "?xml": {
+                "version": "1.0",
+                "encoding": "UTF-8"
+            },
+            "note": {
+                "heading": "Bear",
+                "body": {
+                    "#text": "Bears are called Bären in German!",
+                    "face": "ʕ•ᴥ•ʔ"
+                }
+            }
+        };
+
+        const options = {
+            attributeNamePrefix: "",
+            ignoreAttributes:    false,
+            processEntities: true,
+            htmlEntities: true,
+        };
+        const parser = new XMLParser(options);
+        let result = parser.parse(xmlData);
+
+        expect(result).toEqual(expected);
+    });
+
     it("should throw error if an entity name contains special char", function() {
         const xmlData = `
         <?xml version="1.0" encoding="UTF-8"?>

--- a/src/v5/EntitiesParser.js
+++ b/src/v5/EntitiesParser.js
@@ -13,6 +13,8 @@ const htmlEntities = {
     "copyright" : { regex: /&(copy|#169);/g, val: "©" },
     "reg" : { regex: /&(reg|#174);/g, val: "®" },
     "inr" : { regex: /&(inr|#8377);/g, val: "₹" },
+    "num_dec": { regex: /&#([0-9]{1,7});/g, val : (_, str) => String.fromCharCode(Number.parseInt(str, 10)) },
+    "num_hex": { regex: /&#x([0-9a-fA-F]{1,6});/g, val : (_, str) => String.fromCharCode(Number.parseInt(str, 16)) },
 };
 
 class EntitiesParser{

--- a/src/v5/valueParsers/EntitiesParser.js
+++ b/src/v5/valueParsers/EntitiesParser.js
@@ -13,6 +13,8 @@ const htmlEntities = {
     "copyright" : { regex: /&(copy|#169);/g, val: "©" },
     "reg" : { regex: /&(reg|#174);/g, val: "®" },
     "inr" : { regex: /&(inr|#8377);/g, val: "₹" },
+    "num_dec": { regex: /&#([0-9]{1,7});/g, val : (_, str) => String.fromCharCode(Number.parseInt(str, 10)) },
+    "num_hex": { regex: /&#x([0-9a-fA-F]{1,6});/g, val : (_, str) => String.fromCharCode(Number.parseInt(str, 16)) },
 };
 
 class EntitiesParser{

--- a/src/xmlparser/OrderedObjParser.js
+++ b/src/xmlparser/OrderedObjParser.js
@@ -40,6 +40,8 @@ class OrderedObjParser{
       "copyright" : { regex: /&(copy|#169);/g, val: "©" },
       "reg" : { regex: /&(reg|#174);/g, val: "®" },
       "inr" : { regex: /&(inr|#8377);/g, val: "₹" },
+      "num_dec": { regex: /&#([0-9]{1,7});/g, val : (_, str) => String.fromCharCode(Number.parseInt(str, 10)) },
+      "num_hex": { regex: /&#x([0-9a-fA-F]{1,6});/g, val : (_, str) => String.fromCharCode(Number.parseInt(str, 16)) },
     };
     this.addExternalEntities = addExternalEntities;
     this.parseXml = parseXml;


### PR DESCRIPTION
# Purpose / Goal
<!-- Please specify here what you're planning to achieve by this pull request and how it can help in regard of this work-space. -->
This PR adds a `htmlNumericEntities` option which adds support for parsing HTML numeric entities.


<!-- If it is a bug fix, please mention the issue number. If there is no issue has been raised but the PR directly then it should follow the template given to raise the issue. Like input, expected output, actual output etc. -->


# Type
Please mention the type of PR
<!-- choose one by changing [ ] to [x] -->
* [ ] Bug Fix
* [ ] Refactoring / Technology upgrade
* [x] New Feature

# Benchmarks

## Before
```
Running Suite: XML Parser benchmark
fxp v3 : 43885.453114704054 requests/second
fxp : 28444.884306095257 requests/second
fxp - preserve order : 35582.44370634719 requests/second
xmlbuilder2 : 12279.374624117605 requests/second
xml2js  : 17997.982194339696 requests/second
```

## After
```
Running Suite: XML Parser benchmark
fxp v3 : 56829.18072321323 requests/second
fxp : 35711.03397186936 requests/second
fxp - preserve order : 35048.53534051172 requests/second
xmlbuilder2 : 12565.714384084644 requests/second
xml2js  : 17898.357168570532 requests/second
```