### PR TITLE
fix: validator bag when closing tag is not opened.

### DIFF
--- a/spec/validator_spec.js
+++ b/spec/validator_spec.js
@@ -129,6 +129,12 @@ describe("XML Validator", function () {
         });
     });
 
+    it("should not validate xml with unexpected closing tag", function () {
+        validate("<rootNode><tag></tag1></tag></rootNode>", {
+            InvalidTag: "Closing tag 'tag1' has not been opened."
+        });
+    });
+
     it("should validate xml with comment", function () {
         validate("<rootNode><!-- <tag> - - --><tag>1</tag><tag>val</tag></rootNode>");
     });

--- a/spec/validator_spec.js
+++ b/spec/validator_spec.js
@@ -130,8 +130,8 @@ describe("XML Validator", function () {
     });
 
     it("should not validate xml with unexpected closing tag", function () {
-        validate("<rootNode><tag></tag1></tag></rootNode>", {
-            InvalidTag: "Closing tag 'tag1' has not been opened."
+        validate("</rootNode>", {
+            InvalidTag: "Closing tag 'rootNode' has not been opened."
         });
     });
 

--- a/src/validator.js
+++ b/src/validator.js
@@ -103,6 +103,8 @@ exports.validate = function (xmlData, options) {
             return getErrorObject('InvalidTag', "Closing tag '"+tagName+"' doesn't have proper closing.", getLineNumberForPosition(xmlData, i));
           } else if (attrStr.trim().length > 0) {
             return getErrorObject('InvalidTag', "Closing tag '"+tagName+"' can't have attributes or invalid starting.", getLineNumberForPosition(xmlData, tagStartPos));
+          } else if (tags.length === 0) {
+            return getErrorObject('InvalidTag', "Closing tag '"+tagName+"' has not been opened.", getLineNumberForPosition(xmlData, tagStartPos));
           } else {
             const otg = tags.pop();
             if (tagName !== otg.tagName) {


### PR DESCRIPTION
# Purpose / Goal
<!-- Please specify here what you're planning to achieve by this pull request and how it can help in regard of this work-space. -->
Fixes https://github.com/NaturalIntelligence/fast-xml-parser/issues/620

`fxparser -V a.xml` with input.xml.
```
</html>
```

On current master.
```
            if (tagName !== otg.tagName) {
                                ^

TypeError: Cannot read property 'tagName' of undefined
    at Object.exports.validate (/Users/ryosukefukatani/work/fast-xml-parser/src/validator.js:108:33)
    at callback (/Users/ryosukefukatani/work/fast-xml-parser/src/cli/cli.js:51:29)
    at /Users/ryosukefukatani/work/fast-xml-parser/src/cli/cli.js:78:9
    at FSReqCallback.readFileAfterClose [as oncomplete] (internal/fs/read_file_context.js:63:3)
```

With this change.
```
{
  err: {
    code: 'InvalidTag',
    msg: "Closing tag 'html' has not been opened.",
    line: 1,
    col: 1
  }
}
```

<!-- If it is a bug fix, please mention the issue number. If there is no issue has been raised but the PR directly then it should follow the template given to raise the issue. Like input, expected output, actual output etc. -->


# Type
Please mention the type of PR
<!-- choose one by changing [ ] to [x] -->
* [x] Bug Fix
* [ ] Refactoring / Technology upgrade
* [ ] New Feature

**Note** : Please ensure that you've read contribution [guidelines](https://github.com/NaturalIntelligence/fast-xml-parser/blob/master/docs/CONTRIBUTING.md) before raising this PR. If your PR is in progress, please prepend `[WIP]` in PR title. Your PR will be reviewed when `[WIP]` will be removed from the PR title.

[Bookmark](https://github.com/NaturalIntelligence/fast-xml-parser/stargazers) this repository for further updates.
