### PR TITLE
docs: fix typos in v5 document `fast-xml-parse`

### DIFF
--- a/docs/v5/1. Getting Started.md
+++ b/docs/v5/1. Getting Started.md
@@ -3,7 +3,7 @@
 Example with no configuration
 
 ```js
-const XMLParser = require("fast-xml-parse/v5/XMLParser")
+const XMLParser = require("fast-xml-parser/v5/XMLParser")
 const parser = new XMLParser();
 //read xmlData your own 
 let result = parser.parse(xmlData, true);
@@ -12,7 +12,7 @@ let result = parser.parse(xmlData, true);
 The default response of parse is built by `JsObjOutputBuilder`. FXP v5 comes with 2 more output builders. And you can set your custom output builder too to customize the output.
 
 ```js
-const JsObjOutputBuilder = require("fast-xml-parse/v5/OutputBuilders/JsObjBuilder");
+const JsObjOutputBuilder = require("fast-xml-parser/v5/OutputBuilders/JsObjBuilder");
 
 const parser = new XMLParser({
     OutputBuilder: new JsObjOutputBuilder()

--- a/docs/v5/5. ValueParsers.md
+++ b/docs/v5/5. ValueParsers.md
@@ -12,7 +12,7 @@ Entity and date parsers have to be set.
 Example when you don't override default parsers
 
 ```js
-const JsObjOutputBuilder = require("fast-xml-parse/v5/OutputBuilders/JsObjBuilder");
+const JsObjOutputBuilder = require("fast-xml-parser/v5/OutputBuilders/JsObjBuilder");
 
 const xmlData = `<root>
   <int>   1234    </int>
@@ -44,7 +44,7 @@ Output
 But if you override it then it will use sequence in the order you defined.
 
 ```js
-const JsObjOutputBuilder = require("fast-xml-parse/v5/OutputBuilders/JsObjBuilder");
+const JsObjOutputBuilder = require("fast-xml-parser/v5/OutputBuilders/JsObjBuilder");
 
 const xmlData = `<root>
   <int>   1234    </int>


### PR DESCRIPTION
# Purpose / Goal
There are typos in the v5 documents: `fast-xml-parse` should be `fast-xml-parser`.

https://github.com/NaturalIntelligence/fast-xml-parser/blob/a96b96807207bdde0c4ce6cc31841fda936b4000/docs/v5/1.%20Getting%20Started.md?plain=1#L6-L9

Relevant error message:

```sh
 ERR_PNPM_FETCH_404  GET https://registry.npmjs.org/fast-xml-parse: Not Found - 404

fast-xml-parse is not in the npm registry, or you have no permission to fetch it.
```

So I found and corrected similar typos from v5 document.

# Type
Please mention the type of PR
* [x] Bug Fix
* [ ] Refactoring / Technology upgrade
* [ ] New Feature

