### PR TITLE
fix: get oneListGroup to work as expected for array of strings

### DIFF
--- a/spec/j2x_spec.js
+++ b/spec/j2x_spec.js
@@ -482,7 +482,20 @@ describe("XMLBuilder", function() {
         const expected = `<a><b>1</b><b>2</b></a>`;
         expect(result).toEqual(expected);
     });
-    
+
+    it("should correctly handle values with oneListGroup", function() {
+        const jObj = {
+            "a": [
+                "(first)",
+                "(second)"
+            ],
+        };
+        const builder = new XMLBuilder({oneListGroup:"true", attributesGroupName: "@"});
+        const result = builder.build(jObj);
+        const expected = `<a>(first)(second)</a>`;
+        expect(result).toEqual(expected);
+    });
+
     it('should build tag with only text node', async () => {
         const schema_obj = {
           field: {

--- a/src/xmlbuilder/json2xml.js
+++ b/src/xmlbuilder/json2xml.js
@@ -130,7 +130,13 @@ Builder.prototype.j2x = function(jObj, level) {
             listTagVal += this.processTextOrObjNode(item, key, level)
           }
         } else {
-          listTagVal += this.buildTextValNode(item, key, '', level);
+          if (this.options.oneListGroup) {
+            let textValue = this.options.tagValueProcessor(key, item);
+            textValue = this.replaceEntitiesValue(textValue);
+            listTagVal += textValue;
+          } else {
+            listTagVal += this.buildTextValNode(item, key, '', level);
+          }
         }
       }
       if(this.options.oneListGroup){


### PR DESCRIPTION
If I have `oneListGroup` enabled I would expect that:

```json
{
  "a": ["(first)", "second"]
}
```

Would give me:
```xml
<a>(first)(second)</a>
```

But I get:
```xml
<a>
  <a>(first)</a>
  <a>(second)</a>
</a>
```

This commit fixes that issue.


# Type
Please mention the type of PR
<!-- choose one by changing [ ] to [x] -->
* [X] Bug Fix
* [ ] Refactoring / Technology upgrade
* [ ] New Feature

**Note** : Please ensure that you've read contribution [guidelines](https://github.com/NaturalIntelligence/fast-xml-parser/blob/master/docs/CONTRIBUTING.md) before raising this PR. If your PR is in progress, please prepend `[WIP]` in PR title. Your PR will be reviewed when `[WIP]` will be removed from the PR title.

[Bookmark](https://github.com/NaturalIntelligence/fast-xml-parser/stargazers) this repository for further updates.
