### PR TITLE
Fix node generation when a cdata property is null

### DIFF
--- a/spec/j2x_spec.js
+++ b/spec/j2x_spec.js
@@ -108,6 +108,22 @@ describe("XMLBuilder", function() {
         expect(result).toEqual(expected);
     });
 
+    it('should parse to XML with empty CDATA', function() {
+        const jObj = {
+            a: {
+                $cdata: null,
+            },
+            b: {
+                $cdata: undefined,
+            },
+        };
+        const builder = new XMLBuilder({ cdataPropName: '$cdata' });
+        const result = builder.build(jObj);
+        //console.log(result);
+        const expected = `<a></a><b></b>`;
+        expect(result).toEqual(expected);
+    });
+
     it("should parse to XML with attributes as separate node", function() {
         const jObj = {
             a: {

--- a/src/xmlbuilder/json2xml.js
+++ b/src/xmlbuilder/json2xml.js
@@ -92,6 +92,8 @@ Builder.prototype.j2x = function(jObj, level, ajPath) {
       // null attribute should be ignored by the attribute list, but should not cause the tag closing
       if (this.isAttribute(key)) {
         val += '';
+      } else if (key === this.options.cdataPropName) {
+        val += '';
       } else if (key[0] === '?') {
         val += this.indentate(level) + '<' + key + '?' + this.tagEndChar;
       } else {


### PR DESCRIPTION
# Purpose / Goal

During XML building, CDATA with null value is not handled properly. When a value is null, the cdata property is ignored and treated as a normal node.

This PR aims to resolve this issue (#700) by handling the cdata property when it has a null value.

## Benchmark

### Before Changes

```
Running Suite: XML Builder benchmark
fxp : 73911.77177576702 requests/second
fxp - preserve order : 96821055.83555794 requests/second
xml2js  : 23993.824078178754 requests/second
```

### After Changes

```
Running Suite: XML Builder benchmark
fxp : 71796.8171188612 requests/second
fxp - preserve order : 95102276.51741566 requests/second
xml2js  : 22884.60165181542 requests/second
```

# Type
Please mention the type of PR
* [x] Bug Fix
* [ ] Refactoring / Technology upgrade
* [ ] New Feature

**Note** : Please ensure that you've read contribution [guidelines](https://github.com/NaturalIntelligence/fast-xml-parser/blob/master/docs/CONTRIBUTING.md) before raising this PR. If your PR is in progress, please prepend `[WIP]` in PR title. Your PR will be reviewed when `[WIP]` will be removed from the PR title.

[Bookmark](https://github.com/NaturalIntelligence/fast-xml-parser/stargazers) this repository for further updates.
