### PR TITLE
fix: emit full JSON string from CLI when no output filename specified

### DIFF
--- a/src/cli/cli.js
+++ b/src/cli/cli.js
@@ -57,7 +57,7 @@ if (process.argv[2] === '--help' || process.argv[2] === '-h') {
     if (outputFileName) {
       writeToFile(outputFileName, output);
     } else {
-      console.log(output);
+      console.log(JSON.stringify(output, null, 2));
     }
   };
 


### PR DESCRIPTION
# Purpose / Goal
<!-- Please specify here what you're planning to achieve by this pull request and how it can help in regard of this work-space. -->
Modify emitted CLI standard output to be valid JSON. `console.log(object)` is insufficient with nested input structure. Addresses #709 .

<!-- If it is a bug fix, please mention the issue number. If there is no issue has been raised but the PR directly then it should follow the template given to raise the issue. Like input, expected output, actual output etc. -->


# Type
Please mention the type of PR
<!-- choose one by changing [ ] to [x] -->
* [x] Bug Fix
* [ ] Refactoring / Technology upgrade
* [ ] New Feature

**Note** : Please ensure that you've read contribution [guidelines](https://github.com/NaturalIntelligence/fast-xml-parser/blob/master/docs/CONTRIBUTING.md) before raising this PR. If your PR is in progress, please prepend `[WIP]` in PR title. Your PR will be reviewed when `[WIP]` will be removed from the PR title.

[Bookmark](https://github.com/NaturalIntelligence/fast-xml-parser/stargazers) this repository for further updates.
