### PR TITLE
fix: include CommonJS resources in the npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,11 @@
   "bin": {
     "fxparser": "./src/cli/cli.js"
   },
+  "files": [
+    "lib",
+    "src",
+    "CHANGELOG.md"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/NaturalIntelligence/fast-xml-parser"


### PR DESCRIPTION
# Purpose / Goal
<!-- Please specify here what you're planning to achieve by this pull request and how it can help in regard of this work-space. -->

The `package.json` file didn't declare a "files" attribute, so default files were included, but not the files in the lib folder (which includes CommonJS resources)

<!-- If it is a bug fix, please mention the issue number. If there is no issue has been raised but the PR directly then it should follow the template given to raise the issue. Like input, expected output, actual output etc. -->

Closes #713

I have run npm pack with the new configuration to verify that the content is the same as in https://www.npmjs.com/package/fast-xml-parser/v/5.0.1?activeTab=code and includes the lib folder.

# Type
Please mention the type of PR
<!-- choose one by changing [ ] to [x] -->
* [x] Bug Fix
* [ ] Refactoring / Technology upgrade
* [ ] New Feature

<!--
**Note** : Please ensure that you've read contribution [guidelines](https://github.com/NaturalIntelligence/fast-xml-parser/blob/master/docs/CONTRIBUTING.md) before raising this PR. If your PR is in progress, please prepend `[WIP]` in PR title. Your PR will be reviewed when `[WIP]` will be removed from the PR title.

[Bookmark](https://github.com/NaturalIntelligence/fast-xml-parser/stargazers) this repository for further updates.
-->