### PR TITLE
fix: support numeric entities with values over 0xFFFF

### DIFF
--- a/spec/entities_spec.js
+++ b/spec/entities_spec.js
@@ -383,7 +383,7 @@ describe("XMLParser Entities", function() {
         <?xml version="1.0" encoding="UTF-8"?>
         <note>
             <heading>Bear</heading>
-            <body face="&#x295;&#x2022;&#x1D25;&#x2022;&#x294;">Bears are called B&#228;ren in German!</body>
+            <body face="&#x295;&#x2022;&#x1D25;&#x2022;&#x294;" smile="&#x1F60A;&#128523;">Bears are called B&#228;ren in German!</body>
         </note> `;
 
         const expected = {
@@ -395,7 +395,8 @@ describe("XMLParser Entities", function() {
                 "heading": "Bear",
                 "body": {
                     "#text": "Bears are called Bären in German!",
-                    "face": "ʕ•ᴥ•ʔ"
+                    "face": "ʕ•ᴥ•ʔ",
+                    "smile": "\u{1F60A}\u{1F60B}"
                 }
             }
         };

--- a/src/v6/EntitiesParser.js
+++ b/src/v6/EntitiesParser.js
@@ -13,8 +13,8 @@ const htmlEntities = {
     "copyright" : { regex: /&(copy|#169);/g, val: "©" },
     "reg" : { regex: /&(reg|#174);/g, val: "®" },
     "inr" : { regex: /&(inr|#8377);/g, val: "₹" },
-    "num_dec": { regex: /&#([0-9]{1,7});/g, val : (_, str) => String.fromCharCode(Number.parseInt(str, 10)) },
-    "num_hex": { regex: /&#x([0-9a-fA-F]{1,6});/g, val : (_, str) => String.fromCharCode(Number.parseInt(str, 16)) },
+    "num_dec": { regex: /&#([0-9]{1,7});/g, val : (_, str) => String.fromCodePoint(Number.parseInt(str, 10)) },
+    "num_hex": { regex: /&#x([0-9a-fA-F]{1,6});/g, val : (_, str) => String.fromCodePoint(Number.parseInt(str, 16)) },
 };
 export default class EntitiesParser{
     constructor(replaceHtmlEntities) {

--- a/src/v6/valueParsers/EntitiesParser.js
+++ b/src/v6/valueParsers/EntitiesParser.js
@@ -13,8 +13,8 @@ const htmlEntities = {
     "copyright" : { regex: /&(copy|#169);/g, val: "©" },
     "reg" : { regex: /&(reg|#174);/g, val: "®" },
     "inr" : { regex: /&(inr|#8377);/g, val: "₹" },
-    "num_dec": { regex: /&#([0-9]{1,7});/g, val : (_, str) => String.fromCharCode(Number.parseInt(str, 10)) },
-    "num_hex": { regex: /&#x([0-9a-fA-F]{1,6});/g, val : (_, str) => String.fromCharCode(Number.parseInt(str, 16)) },
+    "num_dec": { regex: /&#([0-9]{1,7});/g, val : (_, str) => String.fromCodePoint(Number.parseInt(str, 10)) },
+    "num_hex": { regex: /&#x([0-9a-fA-F]{1,6});/g, val : (_, str) => String.fromCodePoint(Number.parseInt(str, 16)) },
 };
 
 export default class EntitiesParser{

--- a/src/xmlparser/OrderedObjParser.js
+++ b/src/xmlparser/OrderedObjParser.js
@@ -41,8 +41,8 @@ export default class OrderedObjParser{
       "copyright" : { regex: /&(copy|#169);/g, val: "©" },
       "reg" : { regex: /&(reg|#174);/g, val: "®" },
       "inr" : { regex: /&(inr|#8377);/g, val: "₹" },
-      "num_dec": { regex: /&#([0-9]{1,7});/g, val : (_, str) => String.fromCharCode(Number.parseInt(str, 10)) },
-      "num_hex": { regex: /&#x([0-9a-fA-F]{1,6});/g, val : (_, str) => String.fromCharCode(Number.parseInt(str, 16)) },
+      "num_dec": { regex: /&#([0-9]{1,7});/g, val : (_, str) => String.fromCodePoint(Number.parseInt(str, 10)) },
+      "num_hex": { regex: /&#x([0-9a-fA-F]{1,6});/g, val : (_, str) => String.fromCodePoint(Number.parseInt(str, 16)) },
     };
     this.addExternalEntities = addExternalEntities;
     this.parseXml = parseXml;


### PR DESCRIPTION
# Purpose / Goal
<!-- Please specify here what you're planning to achieve by this pull request and how it can help in regard of this work-space. -->

Numeric entities over U+FFFF would be truncated to their lower two bytes due to use of `String.fromCharCode` which only returns a UTF-16 single code unit. Replacing the relevant calls with `String.fromCodePoint` addresses the problem. (See [caniuse.com](https://caniuse.com/mdn-javascript_builtins_string_fromcodepoint) for compatibility.)

Fixes #725.

<!-- If it is a bug fix, please mention the issue number. If there is no issue has been raised but the PR directly then it should follow the template given to raise the issue. Like input, expected output, actual output etc. -->


# Type
Please mention the type of PR
<!-- choose one by changing [ ] to [x] -->
* [x] Bug Fix
* [ ] Refactoring / Technology upgrade
* [ ] New Feature

**Note** : Please ensure that you've read contribution [guidelines](https://github.com/NaturalIntelligence/fast-xml-parser/blob/master/docs/CONTRIBUTING.md) before raising this PR. If your PR is in progress, please prepend `[WIP]` in PR title. Your PR will be reviewed when `[WIP]` will be removed from the PR title.

[Bookmark](https://github.com/NaturalIntelligence/fast-xml-parser/stargazers) this repository for further updates.
