### PR TITLE
fix: update benchmark so it's buildable

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,33 @@
+# fast-xml-parser benchmarks
+
+Part of [fast-xml-parser](../README.md)
+
+## Building
+
+```shell
+$ npm i
+```
+
+## Testing
+
+### All Benchmarks
+
+```shell
+$ npm t
+```
+
+### Parser Benchmars
+
+```shell
+$ npm run parser
+```
+
+### Builder Benchmarks
+
+```shell
+$ npm run builder
+```
+
+## License
+
+See [../README.md](../README.md#license)

--- a/benchmark/XmlBuilder.mjs
+++ b/benchmark/XmlBuilder.mjs
@@ -6,6 +6,11 @@ const suite = new Benchmark.Suite("XML Builder benchmark");
 import {XMLBuilder} from "../src/fxp.js";
 import xml2js from "xml2js";
 const xml2jsBuilder = new xml2js.Builder();
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+    
+// compatibility
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 import fs from "fs";
 import path from "path";

--- a/benchmark/XmlParser.mjs
+++ b/benchmark/XmlParser.mjs
@@ -5,6 +5,11 @@ import {XMLParser} from "../src/fxp.js";
 import xml2js from "xml2js";
 import fxpv3 from "fast-xml-parser";
 import { convert } from 'xmlbuilder2';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+    
+// compatibility
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const suite = new Benchmark.Suite("XML Parser benchmark");
 

--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "description": "Performance test",
   "scripts": {
-    "perf": "node perfTest3.js"
+    "parser": "node XmlParser.mjs",
+    "builder": "node XmlBuilder.mjs",
+    "test": "npm run parser && npm run builder && node try.mjs"
   },
   "devDependencies": {
     "benchmark": "^2.1.4",

--- a/benchmark/try.mjs
+++ b/benchmark/try.mjs
@@ -2,6 +2,11 @@ import fs from "fs";
 import path from "path";
 // const fileNamePath = path.join(__dirname, "../spec/assets/test.json");//1.5k
 // const jsonData = JSON.parse(fs.readFileSync(fileNamePath).toString());
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+    
+// compatibility
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 
 // const xml2js = require("xml2js");

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -14,7 +14,8 @@ Here is the check list to publish any change
 * Changes are well discussed by raising github issue. So they are well known by other contributors and users
 * Echoing the above point. The purpose / goal for the PR should be mentioned in the description.
 * Multiple unrelated changes should not be clubbed in single PR.
-* Please run perf tests  `$ node benchmark\XmlParser.js` or `$ node benchmark\XmlBuilder.js` before and after the changes. And mention it in PR description.
+* Please run perf tests  `$ node benchmark/XmlParser.mjs` or `$ node benchmark/XmlBuilder.mjs` before and after the changes. And mention it in PR description.
+  * See [benchmark/README.md](../benchmark/README.md) for details
 * If you are adding any dependency (specially if it is not the dev dependency) please check that 
   * it is not dependent on other language packages like c/c++
   * the package is not very old, very new, discontinued, or has any vulnerability etc.


### PR DESCRIPTION
- move files from .js to .mjs so they are usable as modules
- shim __dirname using fileURLToPath
- add a benchmark/README.md explaining the build process (such as it is)
- update CONTRIBUTING.md to link to the new README.md
- fix backslashes in CONTRIBUTING.md


# Purpose / Goal

The benchmark wasn't usable or documented.

Fixes: #730

# Type
Please mention the type of PR
<!-- choose one by changing [ ] to [x] -->
* [X] Bug Fix
* [ ] Refactoring / Technology upgrade
* [ ] New Feature

**Note** : Please ensure that you've read contribution [guidelines](https://github.com/NaturalIntelligence/fast-xml-parser/blob/master/docs/CONTRIBUTING.md) before raising this PR. If your PR is in progress, please prepend `[WIP]` in PR title. Your PR will be reviewed when `[WIP]` will be removed from the PR title.

[Bookmark](https://github.com/NaturalIntelligence/fast-xml-parser/stargazers) this repository for further updates.
