### PR TITLE
Fix captureMetaData casing

### DIFF
--- a/docs/v4/2.XMLparseOptions.md
+++ b/docs/v4/2.XMLparseOptions.md
@@ -1001,9 +1001,9 @@ const parser = new XMLParser(options);
 const output = parser.parse(xmlDataStr);
 ```
 
-## captureMetadata
+## captureMetaData
 
-If `captureMetadata` is true, then a [Symbol](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol) is added to nodes with metadata about that node.
+If `captureMetaData` is true, then a [Symbol](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol) is added to nodes with metadata about that node.
 
 `XMLParser.getMetaDataSymbol()` will return the symbol.  Being a Symbol, this property
 will not normally appear in, for example, `Object.keys`.


### PR DESCRIPTION
# Purpose / Goal
<!-- Please specify here what you're planning to achieve by this pull request and how it can help in regard of this work-space. -->

<!-- If it is a bug fix, please mention the issue number. If there is no issue has been raised but the PR directly then it should follow the template given to raise the issue. Like input, expected output, actual output etc. -->
Docs have inconsistent casing on `captureMetaData` making it confusing as to which is required.


# Type
Please mention the type of PR
<!-- choose one by changing [ ] to [x] -->
* [x] Bug Fix
* [ ] Refactoring / Technology upgrade
* [ ] New Feature

**Note** : Please ensure that you've read contribution [guidelines](https://github.com/NaturalIntelligence/fast-xml-parser/blob/master/docs/CONTRIBUTING.md) before raising this PR. If your PR is in progress, please prepend `[WIP]` in PR title. Your PR will be reviewed when `[WIP]` will be removed from the PR title.

[Bookmark](https://github.com/NaturalIntelligence/fast-xml-parser/stargazers) this repository for further updates.
