### PR TITLE
Add missing exports to fxp commonjs types

### DIFF
--- a/lib/fxp.d.cts
+++ b/lib/fxp.d.cts
@@ -451,7 +451,13 @@ declare namespace fxp {
     XMLParser,
     XMLValidator,
     XMLBuilder,
-    XMLMetaData
+    XMLMetaData,
+    XmlBuilderOptions,
+    X2jOptions,
+    ESchema,
+    ValidationError,
+    strnumOptions,
+    validationOptions,
   }
 }
 


### PR DESCRIPTION
Similar to PR #744, the commonjs version of typing file should export public types. otherwise, we are getting this error when building for commonjs:

> xml-helpers.ts(8,15): error TS2305: Module '"fast-xml-parser"' has no exported member 'XmlBuilderOptions'.

# Purpose / Goal
<!-- Please specify here what you're planning to achieve by this pull request and how it can help in regard of this work-space. -->

<!-- If it is a bug fix, please mention the issue number. If there is no issue has been raised but the PR directly then it should follow the template given to raise the issue. Like input, expected output, actual output etc. -->
related to issue #736

# Type
Please mention the type of PR
<!-- choose one by changing [ ] to [x] -->
* [x] Bug Fix
* [ ] Refactoring / Technology upgrade
* [ ] New Feature
