### PR TITLE
Unexport `X2jOptions` at declaration site

### DIFF
--- a/lib/fxp.d.cts
+++ b/lib/fxp.d.cts
@@ -54,7 +54,7 @@ type ProcessEntitiesOptions = {
   tagFilter?: ((tagName: string, jPath: string) => boolean) | null;
 };
 
-export type X2jOptions = {
+type X2jOptions = {
   /**
    * Preserve the order of tags in resulting JS object
    * 


### PR DESCRIPTION
# Purpose / Goal
<!-- Please specify here what you're planning to achieve by this pull request and how it can help in regard of this work-space. -->

<!-- If it is a bug fix, please mention the issue number. If there is no issue has been raised but the PR directly then it should follow the template given to raise the issue. Like input, expected output, actual output etc. -->

Closes #786

This PR removes the export at `X2jOptions` declaration site in `fxp.d.cts`, and only keeps the export in `fxp` namespace.

I checked, and `import {X2jOptions} from 'fast-xml-parser'` still works after that.

# Type
Please mention the type of PR
<!-- choose one by changing [ ] to [x] -->
* [x] Bug Fix
* [ ] Refactoring / Technology upgrade
* [ ] New Feature

**Note** : Please ensure that you've read contribution [guidelines](https://github.com/NaturalIntelligence/fast-xml-parser/blob/master/docs/CONTRIBUTING.md) before raising this PR. If your PR is in progress, please prepend `[WIP]` in PR title. Your PR will be reviewed when `[WIP]` will be removed from the PR title.

[Bookmark](https://github.com/NaturalIntelligence/fast-xml-parser/stargazers) this repository for further updates.
