### PR TITLE
fix: stopNodes should preserve text content as string (#795)

### DIFF
--- a/spec/stopNodes_spec.js
+++ b/spec/stopNodes_spec.js
@@ -448,11 +448,38 @@ describe("XMLParser StopNodes", function () {
     }
     const parser = new XMLParser(options);
     // console.log(JSON.stringify(parser.parse(xml)));
-    
+
     let result = parser.parse(xmlData);
 
     // console.log(JSON.stringify(result,null,4));
     expect(result).toEqual(expected);
 
+  });
+  it("should preserve text content as string, not parse as number/boolean (#795)", function() {
+    const parser = new XMLParser({ stopNodes: ["*.a"] });
+
+    // Numeric string should remain string
+    let result = parser.parse("<a>6</a>");
+    expect(result).toEqual({ "a": "6" });
+    expect(typeof result.a).toBe("string");
+
+    // Boolean string should remain string
+    result = parser.parse("<a>true</a>");
+    expect(result).toEqual({ "a": "true" });
+    expect(typeof result.a).toBe("string");
+
+    result = parser.parse("<a>false</a>");
+    expect(result).toEqual({ "a": "false" });
+    expect(typeof result.a).toBe("string");
+
+    // Negative/decimal numbers should remain string
+    result = parser.parse("<a>-123.45</a>");
+    expect(result).toEqual({ "a": "-123.45" });
+    expect(typeof result.a).toBe("string");
+
+    // Scientific notation should remain string
+    result = parser.parse("<a>1e10</a>");
+    expect(result).toEqual({ "a": "1e10" });
+    expect(typeof result.a).toBe("string");
   });
 });

--- a/src/xmlparser/OrderedObjParser.js
+++ b/src/xmlparser/OrderedObjParser.js
@@ -96,7 +96,7 @@ function addExternalEntities(externalEntities) {
  * @param {boolean} isLeafNode
  * @param {boolean} escapeEntities
  */
-function parseTextData(val, tagName, jPath, dontTrim, hasAttributes, isLeafNode, escapeEntities) {
+function parseTextData(val, tagName, jPath, dontTrim, hasAttributes, isLeafNode, escapeEntities, doNotParseTagValue) {
   if (val !== undefined) {
     if (this.options.trimValues && !dontTrim) {
       val = val.trim();
@@ -111,6 +111,9 @@ function parseTextData(val, tagName, jPath, dontTrim, hasAttributes, isLeafNode,
       } else if (typeof newval !== typeof val || newval !== val) {
         //overwrite
         return newval;
+      } else if (doNotParseTagValue) {
+        // stopNodes: preserve text content as string, don't parse as number/boolean
+        return val;
       } else if (this.options.trimValues) {
         return parseValue(val, this.options.parseTagValue, this.options.numberParseOptions);
       } else {
@@ -381,7 +384,7 @@ const parseXml = function (xmlData) {
             childNode[":@"] = this.buildAttributesMap(tagExp, jPath, tagName);
           }
           if (tagContent) {
-            tagContent = this.parseTextData(tagContent, tagName, jPath, true, attrExpPresent, true, true);
+            tagContent = this.parseTextData(tagContent, tagName, jPath, true, attrExpPresent, true, true, true);
           }
 
           jPath = jPath.substr(0, jPath.lastIndexOf("."));


### PR DESCRIPTION
## Summary
- Fixes stopNodes content being parsed as numbers/booleans instead of remaining as strings
- `<a>6</a>` with `stopNodes: ["*.a"]` now returns `{ a: "6" }` instead of `{ a: 6 }`

## Problem
When using `stopNodes` option, numeric and boolean-like text content was being converted to JavaScript numbers/booleans. According to the documentation, `stopNodes` should preserve content as raw text.

**Reproduction (from #795):**
```js
const parser = new XMLParser({ stopNodes: ["*.a"] });
console.log(typeof parser.parse("<a>6</a>").a); // "number" - should be "string"
```

## Solution
Added `doNotParseTagValue` parameter to `parseTextData` function and set it to `true` when processing stopNode content. This skips the `parseValue` call that converts strings to numbers/booleans, while still allowing `tagValueProcessor` to work for user customization.

## Test Plan
- [x] All 282 existing tests pass
- [x] Added regression test covering: numeric strings, boolean strings ("true"/"false"), negative/decimal numbers, scientific notation

## Compatibility
- [x] No breaking changes
- [x] Backwards compatible - existing `tagValueProcessor` behavior preserved

Fixes #795