### PR TITLE
fix(types): NodeNext-compatible import in fxp.d.ts (TS2834)

### DIFF
--- a/src/fxp.d.ts
+++ b/src/fxp.d.ts
@@ -1,4 +1,4 @@
-import type { Expression, ReadonlyMatcher } from './pem';
+import type { Expression, ReadonlyMatcher } from './pem.js';
 
 // jPath: true  → string
 // jPath: false → ReadonlyMatcher


### PR DESCRIPTION
## Summary
Fixes #808.

Under `moduleResolution` `"node16"` / `"nodenext"`, TypeScript requires explicit file extensions on relative imports in `.d.ts` files. The ESM types entry (`exports["."].import.types` → `./src/fxp.d.ts`) imported `'./pem'`, which triggers **TS2834** for consumers with `skipLibCheck: false`.

This PR is similar to #810 but without the regression test.

## Change
- Update the type-only import in `src/fxp.d.ts` to `'./pem.js'` (TypeScript resolves this to `pem.d.ts`, matching the emitted `fxp.js` pattern).

## Verification
Local `tsc` with `module` / `moduleResolution` `NodeNext`, `skipLibCheck: false`, and `files` including `src/fxp.d.ts` + `src/pem.d.ts` completes with no errors.