### PR TITLE
fix: stop node namespace prefix parameter ordering in readStopNodeData

### DIFF
--- a/src/xmlparser/OrderedObjParser.js
+++ b/src/xmlparser/OrderedObjParser.js
@@ -757,7 +757,7 @@ function readStopNodeData(xmlData, tagName, i) {
         const closeIndex = findClosingIndex(xmlData, "]]>", i, "StopNode is not closed.") - 2;
         i = closeIndex;
       } else {
-        const tagData = readTagExp(xmlData, i, '>')
+        const tagData = readTagExp(xmlData, i, false)
 
         if (tagData) {
           const openTagName = tagData && tagData.tagName;


### PR DESCRIPTION
# Purpose / Goal

Fix incorrect parameter ordering in `readStopNodeData` that breaks stop node tracking when the tag has a namespace prefix.

# Type
* [x] Bug Fix

`readStopNodeData` calls `readTagExp(xmlData, i, '>')` at line 760, but `'>'` ends up in the `removeNSPrefix` parameter instead of `closingChar`. Since it's truthy, namespace prefixes get stripped from opening tags inside the stop node, while closing tags keep them. This throws off `openTagCount` because opens and closes no longer match.

```js
const parser = new XMLParser({ stopNodes: ["root.ns:code"] });
const result = parser.parse(
  "<root><ns:code>safe <ns:code>nested</ns:code> still raw</ns:code></root>"
);
// result.root["ns:code"] should be "safe <ns:code>nested</ns:code> still raw"
// but instead the stop node exits early at the inner </ns:code>
```

The fix is changing `readTagExp(xmlData, i, '>')` to `readTagExp(xmlData, i, false)` since `closingChar` already defaults to `">"`.