### PR TITLE
fix: resolve numeric character reference external entities

### DIFF
--- a/spec/entities_spec.js
+++ b/spec/entities_spec.js
@@ -537,13 +537,39 @@ describe("XMLParser External Entities", function () {
         }).toThrowError("An entity must be set without '&' and ';'. Eg. use '#xD' for '&#xD;'");
     });
 
-    xit("should set and parse for valid entity set externally", function () {
+    it("should set and parse for valid entity set externally", function () {
         const xmlData = `<note>&unknown;&#xD;last</note> `;
 
         const parser = new XMLParser();
         parser.addEntity("#xD", "\r\n");
-        expect(() => parser.parse(xmlData))
-            .toThrowError(`[EntityReplacer] Invalid character '#' in entity name: "#xD"`);
+        let result = parser.parse(xmlData);
+
+        expect(result.note).toEqual(`&unknown;\r\nlast`);
+    });
+
+    it("should support multiple numeric character reference external entities", function () {
+        const xmlData = `<root>&#xD;&#13;&#x20;&#x41;</root>`;
+
+        const parser = new XMLParser();
+        parser.addEntity("#xD", "\r");
+        parser.addEntity("#13", "\r");
+        parser.addEntity("#x20", " ");
+        parser.addEntity("#x41", "A");
+        let result = parser.parse(xmlData);
+
+        expect(result.root).toEqual("\r\r A");
+    });
+
+    it("should handle hex and decimal numeric external entities together", function () {
+        const xmlData = `<root>Hello&#x20;World&#xD;&#13;End</root>`;
+
+        const parser = new XMLParser();
+        parser.addEntity("#x20", " ");
+        parser.addEntity("#xD", "\r");
+        parser.addEntity("#13", "\r");
+        let result = parser.parse(xmlData);
+
+        expect(result.root).toEqual("Hello World\r\rEnd");
     });
 
     it("External Entity can change the behavior of default entities", function () {

--- a/src/xmlparser/OrderedObjParser.js
+++ b/src/xmlparser/OrderedObjParser.js
@@ -91,8 +91,24 @@ export default class OrderedObjParser {
     } else {
       if (typeof this.options.htmlEntities === "object") namedEntities = this.options.htmlEntities;
       else if (this.options.htmlEntities === true) namedEntities = { ...COMMON_HTML, ...CURRENCY };
-      this.entityDecoder = new EntityDecoder({
-        namedEntities: { ...namedEntities, ...externalEntities },
+
+      // Separate #-prefixed external entities (numeric character reference overrides)
+      // from regular named entities. The EntityDecoder's NCR path intercepts #-prefixed
+      // tokens before named entity lookup, so we handle them via pre-processing.
+      const numericExternalEntities = Object.create(null);
+      const regularExternalEntities = Object.create(null);
+      if (externalEntities) {
+        for (const key of Object.keys(externalEntities)) {
+          if (key.charCodeAt(0) === 35 /* '#' */) {
+            numericExternalEntities[key] = externalEntities[key];
+          } else {
+            regularExternalEntities[key] = externalEntities[key];
+          }
+        }
+      }
+
+      const decoder = new EntityDecoder({
+        namedEntities: { ...namedEntities, ...regularExternalEntities },
         numericAllowed: this.options.htmlEntities,
         limit: {
           maxTotalExpansions: this.options.processEntities.maxTotalExpansions,
@@ -101,6 +117,26 @@ export default class OrderedObjParser {
         }
         //postCheck: resolved => resolved
       });
+
+      // Wrap the decoder to handle #-prefixed external entities (e.g. addEntity('#xD', '\r'))
+      // These must be resolved before the EntityDecoder sees them, since its NCR path
+      // intercepts #-prefixed tokens and ignores the named entity map for them.
+      if (Object.keys(numericExternalEntities).length > 0) {
+        const originalDecode = decoder.decode.bind(decoder);
+        decoder.decode = function(str) {
+          if (typeof str === 'string' && str.indexOf('&') !== -1) {
+            for (const key of Object.keys(numericExternalEntities)) {
+              const entity = '&' + key + ';';
+              if (str.indexOf(entity) !== -1) {
+                str = str.split(entity).join(numericExternalEntities[key]);
+              }
+            }
+          }
+          return originalDecode(str);
+        };
+      }
+
+      this.entityDecoder = decoder;
     }
 
     // Initialize path matcher for path-expression-matcher


### PR DESCRIPTION
## Summary
Fix regression where `addEntity('#xD', '\r')` and similar numeric character reference external entities are silently ignored since v5.7.x.

## Problem
The `addEntity` API documents that numeric character references can be registered as external entities (e.g., `parser.addEntity('#xD', '\r')` for `&#xD;`). This worked before v5.7.0 but broke with the migration to `@nodable/entities`:

- **v5.7.1**: `setExternalEntities()` calls `validateEntityName()` which throws `Invalid character '#' in entity name: "#xD"` 
- **v5.7.2**: The `validateEntityName` error was bypassed by passing external entities through the constructor, but `#`-prefixed entities are still silently ignored because the `EntityDecoder`'s NCR path intercepts `#`-prefixed tokens before checking the named entity map

This breaks downstream users (reported by AWS SDK users in #825).

## Solution
Separate `#`-prefixed external entities from regular named entities. Regular entities are passed to the `EntityDecoder`'s named entity map as before. Numeric (`#`-prefixed) entities are resolved via pre-processing — replacing `&#xD;`, `&#13;`, etc. with their registered values before the `EntityDecoder`'s decode pass runs.

This preserves backward compatibility:
- `addEntity('#xD', '\r')` works correctly again
- Default behavior (no `addEntity`, no `htmlEntities`) is unchanged
- `htmlEntities: true` continues to decode all numeric character references
- Custom `entityDecoder` option is unaffected

## Test Plan
- [x] Re-enabled the disabled test for `addEntity("#xD", "\r\n")`
- [x] Added tests for multiple hex (`&#xD;`, `&#x20;`, `&#x41;`) and decimal (`&#13;`) numeric character reference external entities
- [x] All 316 existing tests pass
- [x] Verified with AWS SDK XML response patterns

Fixes #825