### PR TITLE
fix(validator): reject numeric character references with no digits (&#; and &#x;)

### DIFF
--- a/src/validator.js
+++ b/src/validator.js
@@ -358,11 +358,16 @@ function validateNumberAmpersand(xmlData, i) {
     i++;
     re = /[\da-fA-F]/;
   }
+  // Per the XML 1.0 CharRef production a numeric reference must contain at
+  // least one digit; "&#;" and "&#x;" are invalid. Without this guard the
+  // loop returns success on a ';' that immediately follows "&#"/"&#x".
+  let hasDigit = false;
   for (; i < xmlData.length; i++) {
     if (xmlData[i] === ';')
-      return i;
+      return hasDigit ? i : -1;
     if (!xmlData[i].match(re))
       break;
+    hasDigit = true;
   }
   return -1;
 }


### PR DESCRIPTION
## Bug

`XMLValidator.validate` reports malformed numeric character references as **valid**:

```js
const { XMLValidator } = require("fast-xml-parser");
XMLValidator.validate("<r>&#x;</r>"); // true  (should be invalid)
XMLValidator.validate("<r>&#;</r>");  // true  (should be invalid)
XMLValidator.validate("<r>&#xG;</r>");// {err:...} invalid  (control — bad hex IS rejected)
```

Per the XML 1.0 `CharRef` production, a numeric reference must contain at least one digit (`&#[0-9]+;` or `&#x[0-9a-fA-F]+;`). `&#;` and `&#x;` have none.

## Cause

`src/validator.js`, `validateNumberAmpersand`: the scan loop checks for `;` **before** requiring any digit, so a `;` immediately following `&#` or `&#x` returns a success index with zero digits consumed.

```js
for (; i < xmlData.length; i++) {
  if (xmlData[i] === 