### PR TITLE
Harden GitHub Actions workflows

### DIFF
--- a/.github/actionlint-matcher.json
+++ b/.github/actionlint-matcher.json
@@ -1,0 +1,17 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "actionlint",
+      "pattern": [
+        {
+          "regexp": "^(?:\\x1b\\[\\d+m)?(.+?)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*: (?:\\x1b\\[\\d+m)*(.+?)(?:\\x1b\\[\\d+m)* \\[(.+?)\\]$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "message": 4,
+          "code": 5
+        }
+      ]
+    }
+  ]
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  cooldown:
+    default-days: 7
+  directory: "/"
+  schedule:
+    interval: monthly

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,74 @@
+name: codeql
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+  schedule:
+    - cron: '0 6 * * MON'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  analysis:
+    name: analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.sha }}
+      cancel-in-progress: false
+
+    permissions:
+      actions: read          # Scan GitHub Actions workflows
+      contents: read         # Checkout the repository
+      security-events: write # Store results in the Security tab
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'actions', 'javascript' ]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
+        show-progress: false
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+      with:
+        languages: ${{ matrix.language }}
+        queries: security
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+      with:
+        category: '/language:${{ matrix.language }}'
+
+  codeql:
+    if: ${{ !cancelled() }}
+    name: codeql
+    needs: [ analysis ]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.sha }}
+      cancel-in-progress: false
+
+    steps:
+    - name: Report status
+      shell: bash
+      env:
+        SCAN_SUCCESS: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
+      run: |
+        if [ "${SCAN_SUCCESS}" == "true" ]
+        then
+          echo 'CodeQL analysis successful ✅'
+        else
+          echo 'CodeQL analysis failed ❌'
+          exit 1
+        fi

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -2,11 +2,23 @@ name: Greetings
 
 on: [issues]
 
+permissions: {}
+
 jobs:
   greeting:
+    name: greeting
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.issue.number || github.ref }}
+      cancel-in-progress: false
+
+    permissions:
+      issues: write # Needed to comment on issues
+
     steps:
-    - uses: actions/first-interaction@v1
+    - uses: actions/first-interaction@3c71ce730280171fd1cfb57c00c774f8998586f7 # v1
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         issue-message: 'We''re glad you find this project helpful. We''ll try to address this issue ASAP. You can join Discord channel(https://discord.gg/X4Qp9u6Vz) for anonucements and pre release discussions. Don''t forget to star this repo.'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,47 @@
+name: lint
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  lint:
+    name: Lint workflows
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: false
+
+    env:
+      FORCE_COLOR: 1
+      TERM: xterm
+
+    permissions:
+      actions: read # Scan GitHub Actions workflows
+      contents: read # Checkout the repository
+      security-events: write # Store results in the Security tab
+
+    steps:
+
+    - name: Checkout code
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
+        show-progress: false
+
+    - name: Add actionlint problem matcher
+      run: echo "::add-matcher::.github/actionlint-matcher.json"
+
+    - name: Lint workflows with actionlint
+      uses: docker://rhysd/actionlint:1.7.12@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667
+      with:
+        args: -color
+
+    - name: Lint workflows with zizmor
+      uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,6 +1,3 @@
-# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
-
 name: Node.js CI
 
 on:
@@ -9,24 +6,42 @@ on:
   pull_request:
     branches: [ master ]
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   build:
+    name: build
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.sha }}
+      cancel-in-progress: false
+
+    permissions:
+      contents: read
 
     strategy:
       matrix:
         node-version: [14.x, 16.x, 18.x, 20.x, 22.x]
 
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
+
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: ${{ matrix.node-version }}
+        package-manager-cache: false
+
     - name: Set PUBLISH_PLEASE_DISABLE_PROMPT
       run: echo "PUBLISH_PLEASE_DISABLE_PROMPT=true" >> $GITHUB_ENV
-    - run: npm install --ignore-scripts
-    - run: npm run test
+
+    - name: Install dependencies
+      run: npm install --ignore-scripts
+
+    - name: Run tests
+      run: npm run test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,29 +5,38 @@ on:
     tags:
       - 'v*'
 
-permissions:
-  contents: write   # needed to create the GitHub release
-  id-token: write    # needed for npm trusted publishing (OIDC)
+permissions: {}
 
 jobs:
   publish:
+    name: publish
     runs-on: ubuntu-latest
-    # If you set an "Environment name" on the npm trusted publisher page,
-    # uncomment the line below and use the same name. This lets you add a
-    # required-reviewer gate in repo Settings > Environments if you want
-    # one last manual "approve" click before publish actually runs.
-    environment: npm-publish
+    timeout-minutes: 10
+
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: false
+
+    environment:
+      name: npm-publish
+      deployment: false
+
+    permissions:
+      contents: write # Needed to create the GitHub release
+      id-token: write # Needed for npm trusted publishing (OIDC)
 
     steps:
       - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Setup Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
+          package-manager-cache: false
           registry-url: 'https://registry.npmjs.org'
-          cache: 'npm'
 
       - name: Install dependencies
         run: npm ci
@@ -44,7 +53,9 @@ jobs:
       - name: Publish to npm
         run: npm publish
 
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda
-        with:
-          generate_release_notes: true
+      - name: Create GitHub release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${GITHUB_REF_NAME}"--generate-notes --repo "${GITHUB_REPOSITORY}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,4 +58,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create "${GITHUB_REF_NAME}"--generate-notes --repo "${GITHUB_REPOSITORY}"
+          gh release create "${GITHUB_REF_NAME}" --generate-notes --repo "${GITHUB_REPOSITORY}"

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,4 @@
+rules:
+  dependabot-cooldown:
+    config:
+      days: 7


### PR DESCRIPTION
# Purpose / Goal

Contributes to #814 by:

- Add [CodeQL](https://codeql.github.com/) analysis.
- Add [actionlint](https://github.com/rhysd/actionlint) analysis.
- Add [zizmor](https://zizmor.sh) analysis.
- Fix zizmor findings by:
  - Adding version comments to GitHub Actions pins.
  - Using latest GitHub Actions versions.
  - Adding timeouts.
  - Adding concurrency.
  - Refactoring permissions to least privilege.
  - Removing third-party actions.
  - Adding dependabot with cooldown.
  - Disabling npm caching.

Recommended actions post-merge:

1. Enable [Require actions to be pinned to a full-length commit SHA](https://github.blog/changelog/2025-08-15-github-actions-policy-now-supports-blocking-and-sha-pinning-actions/)
2. Enable [Immutable releases](https://github.blog/changelog/2025-10-28-immutable-releases-are-now-generally-available/)

# Type

* [ ] Bug Fix
* [x] Refactoring / Technology upgrade
* [ ] New Feature
