### PR TITLE
fix: reject self-closing tags as multiple root nodes in validator

### DIFF
--- a/spec/validator_spec.js
+++ b/spec/validator_spec.js
@@ -403,6 +403,30 @@ describe("should not validate XML documents with multiple root nodes", () => {
             InvalidXml: 'Multiple possible root nodes found.'
         }, 5);
     });
+
+    it('when a self closing root node is followed by another self closing node', () => {
+        validate(`<xml/><xml2/>`, {
+            InvalidXml: 'Multiple possible root nodes found.'
+        });
+    });
+
+    it('when a self closing root node is followed by a paired node', () => {
+        validate(`<xml/><xml2></xml2>`, {
+            InvalidXml: 'Multiple possible root nodes found.'
+        });
+    });
+
+    it('when a paired root node is followed by a self closing node', () => {
+        validate(`<xml></xml><xml2/>`, {
+            InvalidXml: 'Multiple possible root nodes found.'
+        });
+    });
+
+    it('when a self closing root node is followed by trailing text', () => {
+        validate(`<xml/>extra`, {
+            InvalidXml: 'Extra text at the end'
+        });
+    });
 });
 
 describe("should report correct line numbers for unclosed tags", () => {

--- a/src/validator.js
+++ b/src/validator.js
@@ -91,6 +91,14 @@ export function validate(xmlData, options) {
           const isValid = validateAttributeString(attrStr, options);
           if (isValid === true) {
             tagFound = true;
+            //a self closing tag at the root level is a complete root element
+            if (tags.length === 0) {
+              //if the root level has already been reached, this is a second root
+              if (reachedRoot === true) {
+                return getErrorObject('InvalidXml', 'Multiple possible root nodes found.', getLineNumberForPosition(xmlData, tagStartPos));
+              }
+              reachedRoot = true;
+            }
             //continue; //text may presents after self closing tag
           } else {
             //the result from the nested function returns the position of the error within the attribute


### PR DESCRIPTION
## Problem

`XMLValidator.validate` only detects multiple root elements when the roots contain child content. A **self-closing** root element silently passes validation, even though the XML 1.0 spec requires [exactly one root element](https://www.w3.org/TR/xml/#sec-well-formed):

> There is exactly one element, called the root, or document element, no part of which appears in the content of any other element.

```js
const { XMLValidator } = require("fast-xml-parser");

XMLValidator.validate("<a></a><b></b>"); // correctly INVALID: "Multiple possible root nodes found."
XMLValidator.validate("<a/><b/>");        // BUG: returns true (valid)
XMLValidator.validate("<a/><b/><c/>");    // BUG: returns true (valid)
XMLValidator.validate("<a/>extra");       // BUG: returns true (valid)
XMLValidator.validate("<a></a><b/>");     // BUG: returns true (valid)
```

This is the self-closing counterpart of #207 / #210, which only fixed the paired-tag case.

## Root cause

In `src/validator.js`, the `reachedRoot` flag is set to `true` only in the **closing-tag** branch when the tag stack empties. The duplicate-root guard (`Multiple possible root nodes found.`) and the trailing-text guard (`Extra text at the end`) both depend on that flag.

A self-closing tag is handled in its own branch and never sets `reachedRoot`, so a self-closing root never marks the document as complete. Any node that follows it therefore escapes both guards.

## Fix

In the self-closing branch, when the tag is at depth 0 (`tags.length === 0`) it *is* a complete root element. Mark `reachedRoot = true`, and if the root level had already been reached, reject the second root with the existing `Multiple possible root nodes found.` error. This reuses the existing error codes and lets the trailing-text guard fire too.

## Tests

Added to `spec/validator_spec.js` under the existing `should not validate XML documents with multiple root nodes` block. The new cases fail without the fix and pass with it; the full suite (`319 specs`) stays green, and single self-closing roots (`<a/>`, `<a/>` followed by whitespace/comments/PIs) remain valid.

- self-closing root followed by another self-closing node
- self-closing root followed by a paired node
- paired root followed by a self-closing node
- self-closing root followed by trailing text