### PR TITLE
docs: fix two 404 documentation links

### DIFF
--- a/.github/feature_template.md
+++ b/.github/feature_template.md
@@ -7,4 +7,4 @@ Please check README or [spec](https://github.com/NaturalIntelligence/fast-xml-pa
 **Attention**
 * Check [how to](https://github.com/Roshanjossey/first-contributions) to know more about raising PR, merging etc.
 * **Don't stretch**. If you complete a card in long time, there is a possibility that other developers finish their part and you face code conflicts which may increase code complexity for you. So it is always good to complete a card ASAP. 
-* Read [Contribution](https://github.com/NaturalIntelligence/fast-xml-parser/blob/master/CONTRIBUTING.md) guidelines
+* Read [Contribution](https://github.com/NaturalIntelligence/fast-xml-parser/blob/master/docs/CONTRIBUTING.md) guidelines

--- a/docs/v4, v5/3.XMLBuilder.md
+++ b/docs/v4, v5/3.XMLBuilder.md
@@ -2,7 +2,7 @@ XML Builder can be used to parse a JS object into XML.
 
 XML Builder was the part of [fast-xml-parser](https://github.com/NaturalIntelligence/fast-xml-builder) for years. But considering that any bug in builder may false-alarm the users who are only using parser and vice-versa, we have decided to split it into a separate package.
 
-Please visit [builder-docs](https://github.com/NaturalIntelligence/fast-xml-builder/blob/master/docs/README.md) for more information.
+Please visit [builder-docs](https://github.com/NaturalIntelligence/fast-xml-builder/blob/main/docs/Builder_v1.md) for more information.
 
 ## Migration
 


### PR DESCRIPTION
Two documentation links currently return 404:

1. `.github/feature_template.md` points contributors at `blob/master/CONTRIBUTING.md`, but the file lives at [`docs/CONTRIBUTING.md`](https://github.com/NaturalIntelligence/fast-xml-parser/blob/master/docs/CONTRIBUTING.md) — there is no CONTRIBUTING.md at the repository root. Anyone following the new-feature template hits a 404.
2. `docs/v4, v5/3.XMLBuilder.md` links to `fast-xml-builder/blob/master/docs/README.md`. That repo's default branch is `main` (not `master`) and it has no `docs/README.md`; the builder documentation is [`docs/Builder_v1.md`](https://github.com/NaturalIntelligence/fast-xml-builder/blob/main/docs/Builder_v1.md).

Both replacements return 200.