### PR TITLE
test: drop shadowed ignoreAttributes option

### DIFF
--- a/spec/pathExpression_spec.js
+++ b/spec/pathExpression_spec.js
@@ -326,7 +326,6 @@ describe("Path-Expression-Matcher Integration", function () {
       const userExpr = new Expression("root.user");
 
       const parser = new XMLParser({
-        ignoreAttributes: false,
         jPath: false,
         ignoreAttributes: (attrName, matcher) => {
           // console.log(attrName, matcher.getCurrentTag())


### PR DESCRIPTION
`spec/pathExpression_spec.js` sets `ignoreAttributes` twice in the same object literal:

```js
const parser = new XMLParser({
  ignoreAttributes: false,
  jPath: false,
  ignoreAttributes: (attrName, matcher) => { ... }
});
```

The later function wins, so the boolean never reaches the parser. esbuild flags it as `duplicate-object-key`, and most lint configs would too.

The test still passes for the right reason today, since the function is what the spec is about. The risk is the reverse reading: the literal looks like it exercises `ignoreAttributes: false` alongside the function, so anyone later removing the function would assume boolean behaviour was still covered here when it never was.

Removing the dead line only. 21 specs in the file pass, and the esbuild duplicate-key warning is gone.

Modest severity, flagging that honestly — it's dead code in a test rather than a behaviour bug.